### PR TITLE
Increase timeout: waiting longer for action server to become available

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -97,7 +97,7 @@ public:
       RCLCPP_ERROR(
         node_->get_logger(), "\"%s\" action server not available after waiting for 20 s",
         action_name.c_str());
-      throw std::runtime_error(std::string("Action server %s not available", action_name.c_str()));
+      throw std::runtime_error(std::string("Action server ") + action_name +  std::string(" not available"));
     }
   }
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_node.hpp
@@ -93,9 +93,9 @@ public:
 
     // Make sure the server is actually there before continuing
     RCLCPP_DEBUG(node_->get_logger(), "Waiting for \"%s\" action server", action_name.c_str());
-    if (!action_client_->wait_for_action_server(10s)) {
+    if (!action_client_->wait_for_action_server(20s)) {
       RCLCPP_ERROR(
-        node_->get_logger(), "\"%s\" action server not available after waiting for 10 s",
+        node_->get_logger(), "\"%s\" action server not available after waiting for 20 s",
         action_name.c_str());
       throw std::runtime_error(std::string("Action server %s not available", action_name.c_str()));
     }


### PR DESCRIPTION
@tonynajjar  did it before increasing from 1 second to 10 seconds, as it transpired from several daily system tests that 
even 10 seconds are not enough, leading to a failed test with nav2 initialization failure. I am increasing it from 10s to 20s, and I see this change as not affecting operations, but rather decreasing false negatives for daily system test reports.