### PR TITLE
AMRNAV-3826 Fix for nav2_velocity_smoother

### DIFF
--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -209,11 +209,15 @@ double VelocitySmoother::applyConstraints(
 
 void VelocitySmoother::smootherTimer()
 {
+  // Wait until the first command is received
+  if (command_==nullptr)
+  {
+    return;
+  }
   auto cmd_vel = std::make_unique<geometry_msgs::msg::Twist>();
 
   // Check for velocity timeout. If nothing received, publish zeros to stop robot
-  // Fix for sim time. False here assumes that velocity command was received and leads to an error on startup
-  if ((now() - last_command_time_ > velocity_timeout_) or (last_command_time_.nanoseconds() == 0)) {
+  if (now() - last_command_time_ > velocity_timeout_) {
     last_cmd_ = geometry_msgs::msg::Twist();
     if (!stopped_) {
       smoothed_cmd_pub_->publish(std::move(cmd_vel));

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -210,10 +210,10 @@ double VelocitySmoother::applyConstraints(
 void VelocitySmoother::smootherTimer()
 {
   // Wait until the first command is received
-  if (command_==nullptr)
-  {
+  if (!command_) {
     return;
   }
+
   auto cmd_vel = std::make_unique<geometry_msgs::msg::Twist>();
 
   // Check for velocity timeout. If nothing received, publish zeros to stop robot

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -212,7 +212,8 @@ void VelocitySmoother::smootherTimer()
   auto cmd_vel = std::make_unique<geometry_msgs::msg::Twist>();
 
   // Check for velocity timeout. If nothing received, publish zeros to stop robot
-  if (now() - last_command_time_ > velocity_timeout_) {
+  // Fix for sim time. False here assumes that velocity command was received and leads to an error on startup
+  if ((now() - last_command_time_ > velocity_timeout_) or (last_command_time_.nanoseconds() == 0)) {
     last_cmd_ = geometry_msgs::msg::Twist();
     if (!stopped_) {
       smoothed_cmd_pub_->publish(std::move(cmd_vel));


### PR DESCRIPTION
---

## Basic Info

| Info | Fix for nav2_velocity_smoother|
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |

---
Related deep_cv PR: https://github.com/logivations/deep_cv/pull/4793

## Description of contribution in a few bullet points


* Added condition to fix an error when using sim time

![Screenshot from 2023-01-09 08-37-25](https://user-images.githubusercontent.com/87417416/211260503-a5e2c3c4-48f9-43e9-b88c-77212da30932.png)



---

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
