### PR TITLE
BT service node: add option to succeed when sending request is not needed

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_service_node.hpp
@@ -131,12 +131,17 @@ public:
       // reset the flag to send the request or not,
       // allowing the user the option to set it in on_tick
       should_send_request_ = true;
+      should_fail_not_sent_request_ = true;
 
       // user defined callback, may modify "should_send_request_".
       on_tick();
 
       if (!should_send_request_) {
-        return BT::NodeStatus::FAILURE;
+        if (should_fail_not_sent_request_) {
+            return BT::NodeStatus::FAILURE;
+        } else {
+            return BT::NodeStatus::SUCCESS;
+        }
       }
 
       future_result_ = service_client_->async_send_request(request_).share();
@@ -253,6 +258,7 @@ protected:
 
   // Can be set in on_tick or on_wait_for_result to indicate if a request should be sent.
   bool should_send_request_;
+  bool should_fail_not_sent_request_;
 };
 
 }  // namespace nav2_behavior_tree


### PR DESCRIPTION
it is used in https://github.com/logivations/deep_cv/pull/5306