### PR TITLE
AMRNAV-4638 fix missing behavior tree logs

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/behavior_tree_engine.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "rclcpp/rclcpp.hpp"
 
 #include "behaviortree_cpp_v3/behavior_tree.h"
 #include "behaviortree_cpp_v3/bt_factory.h"
@@ -61,6 +62,7 @@ public:
     BT::Tree * tree,
     std::function<void()> onLoop,
     std::function<bool()> cancelRequested,
+    rclcpp::Logger logger,
     std::chrono::milliseconds loopTimeout = std::chrono::milliseconds(10));
 
   /**

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -243,8 +243,10 @@ void BtActionServer<ActionT>::executeCallback()
     };
 
   // Execute the BT that was previously created in the configure step
-  nav2_behavior_tree::BtStatus rc = bt_->run(tree_, on_loop, is_canceling, bt_loop_duration_);
+  nav2_behavior_tree::BtStatus rc = bt_->run(tree_, on_loop, is_canceling, logger_, bt_loop_duration_);
 
+
+  topic_logger_->flush();
   // Make sure that the Bt is not in a running state from a previous execution
   // note: if all the ControlNodes are implemented correctly, this is not needed.
   bt_->haltAllActions(tree_->rootNode());
@@ -261,7 +263,7 @@ void BtActionServer<ActionT>::executeCallback()
       break;
 
     case nav2_behavior_tree::BtStatus::FAILED:
-      RCLCPP_ERROR(logger_, "Goal failed");
+      RCLCPP_ERROR(logger_, "Goal failed. New");
       action_server_->terminate_current(result);
       break;
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -245,8 +245,9 @@ void BtActionServer<ActionT>::executeCallback()
   // Execute the BT that was previously created in the configure step
   nav2_behavior_tree::BtStatus rc = bt_->run(tree_, on_loop, is_canceling, logger_, bt_loop_duration_);
 
-
+  // send remaining logs
   topic_logger_->flush();
+  
   // Make sure that the Bt is not in a running state from a previous execution
   // note: if all the ControlNodes are implemented correctly, this is not needed.
   bt_->haltAllActions(tree_->rootNode());
@@ -263,7 +264,7 @@ void BtActionServer<ActionT>::executeCallback()
       break;
 
     case nav2_behavior_tree::BtStatus::FAILED:
-      RCLCPP_ERROR(logger_, "Goal failed. New");
+      RCLCPP_ERROR(logger_, "Goal failed");
       action_server_->terminate_current(result);
       break;
 

--- a/nav2_behavior_tree/src/behavior_tree_engine.cpp
+++ b/nav2_behavior_tree/src/behavior_tree_engine.cpp
@@ -38,6 +38,7 @@ BehaviorTreeEngine::run(
   BT::Tree * tree,
   std::function<void()> onLoop,
   std::function<bool()> cancelRequested,
+  rclcpp::Logger logger,
   std::chrono::milliseconds loopTimeout)
 {
   rclcpp::WallRate loopRate(loopTimeout);
@@ -59,7 +60,7 @@ BehaviorTreeEngine::run(
     }
   } catch (const std::exception & ex) {
     RCLCPP_ERROR(
-      rclcpp::get_logger("BehaviorTreeEngine"),
+      logger,
       "Behavior tree threw exception: %s. Exiting with failure.", ex.what());
     return BtStatus::FAILED;
   }


### PR DESCRIPTION
Errors are not sent to rosout. Not sure why, but passing the logger fixes the problem.