### PR TITLE
Fix free_goal_vel type

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/follow_path_action.hpp
@@ -64,7 +64,7 @@ public:
       {
         BT::InputPort<nav_msgs::msg::Path>("path", "Path to follow"),
         BT::InputPort<std::string>("controller_id", ""),
-        BT::InputPort<std::string>("free_goal_vel", "Don't stop when goal reached"),
+        BT::InputPort<bool>("free_goal_vel", "Don't stop when goal reached"),
         BT::InputPort<std::string>("goal_checker_id", ""),
       });
   }


### PR DESCRIPTION
In the interface type is bool, in the BT node its string. It blocks us from passing bool blackboard variables as an input here