### PR TITLE
AMRNAV-5586: Wait BT node doesn't work with double values 

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/wait_action.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/action/wait_action.hpp
@@ -53,7 +53,7 @@ public:
   {
     return providedBasicPorts(
       {
-        BT::InputPort<int>("wait_duration", 1, "Wait time")
+        BT::InputPort<double>("wait_duration", 1, "Wait time")
       });
   }
 };

--- a/nav2_behavior_tree/plugins/action/wait_action.cpp
+++ b/nav2_behavior_tree/plugins/action/wait_action.cpp
@@ -26,7 +26,7 @@ WaitAction::WaitAction(
   const BT::NodeConfiguration & conf)
 : BtActionNode<nav2_msgs::action::Wait>(xml_tag_name, action_name, conf)
 {
-  int duration;
+  double duration;
   getInput("wait_duration", duration);
   if (duration <= 0) {
     RCLCPP_WARN(
@@ -35,11 +35,13 @@ WaitAction::WaitAction(
     duration *= -1;
   }
 
-  goal_.time.sec = duration;
+  goal_.time.sec = int(duration);
+  goal_.time.nanosec = int((duration - goal_.time.sec) * pow(10, 9));
 }
 
 void WaitAction::on_tick()
 {
+  std::cout << "on_tick in waut action called\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n";
   increment_recovery_count();
 }
 

--- a/nav2_behavior_tree/plugins/action/wait_action.cpp
+++ b/nav2_behavior_tree/plugins/action/wait_action.cpp
@@ -31,7 +31,7 @@ WaitAction::WaitAction(
   if (duration <= 0) {
     RCLCPP_WARN(
       node_->get_logger(), "Wait duration is negative or zero "
-      "(%i). Setting to positive.", duration);
+      "(%f). Setting to positive.", duration);
     duration *= -1;
   }
 
@@ -41,7 +41,9 @@ WaitAction::WaitAction(
 
 void WaitAction::on_tick()
 {
-  std::cout << "on_tick in waut action called\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n";
+  for (int i = 0; i < 10; ++i) {
+    std::cout << "on_tick in waut action called" << std::endl;
+  }
   increment_recovery_count();
 }
 

--- a/nav2_behavior_tree/plugins/action/wait_action.cpp
+++ b/nav2_behavior_tree/plugins/action/wait_action.cpp
@@ -41,9 +41,6 @@ WaitAction::WaitAction(
 
 void WaitAction::on_tick()
 {
-  for (int i = 0; i < 10; ++i) {
-    std::cout << "on_tick in waut action called" << std::endl;
-  }
   increment_recovery_count();
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [AMRNAV-5586](https://lvserv01.logivations.com/browse/AMRNAV-5586)|
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on |  |

---

Also see this [PR](https://github.com/logivations/navigation2/pull/48), as the AMRNAV-5586 and AMRNAV-5586-2 branches are the same, but have different root branches

## Description of contribution in a few bullet points
wait_duration port for Wait node is an integer, so if we pass something like 1.3 or 2.42 than it will automatically cast to nearest integer value, so i changed type of this port from int to double.
<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see alot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in navigation.ros.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
