### PR TITLE
AMRNAV-6230 Fix collision monitor min_vel_before_stop parameter

### DIFF
--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -30,15 +30,15 @@ struct Velocity
 
   inline bool operator<(const Velocity & second) const
   {
-    const double first_vel = getMagnitudeSq();
-    const double second_vel = second.getMagnitudeSq();
+    const double first_vel = getMagnitude();
+    const double second_vel = second.getMagnitude();
     // This comparison includes rotations in place, where linear velocities are equal to zero
     return first_vel < second_vel;
   }
 
   inline bool operator<(const double & second) const
   {
-    const double first_vel = getMagnitudeSq();
+    const double first_vel = getMagnitude();
     return first_vel < second;
   }
 
@@ -47,9 +47,9 @@ struct Velocity
     return {x * mul, y * mul, tw * mul};
   }
 
-  inline double getMagnitudeSq() const
+  inline double getMagnitude() const
   {
-    return x * x + y * y + tw * tw;
+    return sqrt(x * x + y * y + tw * tw);
   }
 
   inline bool isZero() const

--- a/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/types.hpp
@@ -16,6 +16,7 @@
 #define NAV2_COLLISION_MONITOR__TYPES_HPP_
 
 #include <string>
+#include <cmath>
 
 namespace nav2_collision_monitor
 {
@@ -29,21 +30,26 @@ struct Velocity
 
   inline bool operator<(const Velocity & second) const
   {
-    const double first_vel = x * x + y * y + tw * tw;
-    const double second_vel = second.x * second.x + second.y * second.y + second.tw * second.tw;
+    const double first_vel = getMagnitudeSq();
+    const double second_vel = second.getMagnitudeSq();
     // This comparison includes rotations in place, where linear velocities are equal to zero
     return first_vel < second_vel;
   }
 
   inline bool operator<(const double & second) const
   {
-    const double first_vel = x * x + y * y + tw * tw;
+    const double first_vel = getMagnitudeSq();
     return first_vel < second;
   }
 
   inline Velocity operator*(const double & mul) const
   {
     return {x * mul, y * mul, tw * mul};
+  }
+
+  inline double getMagnitudeSq() const
+  {
+    return x * x + y * y + tw * tw;
   }
 
   inline bool isZero() const

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -543,19 +543,25 @@ bool CollisionMonitor::processApproach(
   if (!polygon->isShapeSet()) {
     return false;
   }
+  double min_vel = polygon->getMinVelBeforeStop();
+  const double min_vel_sq = min_vel * min_vel;
+  double collision_time = -1.0;
 
-  // Obtain time before a collision
-  const double collision_time = polygon->getCollisionTime(collision_points, velocity);
+  // Obtain time before a collision, using max(velocity, min_vel_before_stop)
+  if((velocity < min_vel_sq) && (min_vel != -1.0)){
+    const double vel_magnitude_sq = velocity.getMagnitudeSq();
+    const double ratio = min_vel_sq / vel_magnitude_sq;
+    collision_time = polygon->getCollisionTime(collision_points, velocity * ratio);
+  } else {
+    collision_time = polygon->getCollisionTime(collision_points, velocity);
+  } 
   if (collision_time >= 0.0) {
     // If collision will occurr, reduce robot speed
     const double change_ratio = collision_time / polygon->getTimeBeforeCollision();
     const Velocity safe_vel = velocity * change_ratio;
-    // Check that currently calculated velocity is safer than
-    // chosen for previous shapes one
 
-    double min_vel = polygon->getMinVelBeforeStop();
     if (min_vel != -1.0) {
-      if (safe_vel < min_vel) {
+      if (safe_vel < min_vel_sq) {
         robot_action.action_type = APPROACH;
         robot_action.req_vel.x = 0.0;
         robot_action.req_vel.y = 0.0;
@@ -564,6 +570,8 @@ bool CollisionMonitor::processApproach(
       }
     }
 
+    // Check that currently calculated velocity is safer than
+    // chosen for previous shapes one
     if (safe_vel < robot_action.req_vel) {
       robot_action.polygon_name = polygon->getName();
       robot_action.action_type = APPROACH;

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -544,13 +544,11 @@ bool CollisionMonitor::processApproach(
     return false;
   }
   double min_vel = polygon->getMinVelBeforeStop();
-  const double min_vel_sq = min_vel * min_vel;
   double collision_time = -1.0;
 
   // Obtain time before a collision, using max(velocity, min_vel_before_stop)
-  if((velocity < min_vel_sq) && (min_vel != -1.0)){
-    const double vel_magnitude_sq = velocity.getMagnitudeSq();
-    const double ratio = min_vel_sq / vel_magnitude_sq;
+  if((min_vel != -1.0) && (velocity < min_vel)){
+    const double ratio = min_vel / velocity.getMagnitude();
     collision_time = polygon->getCollisionTime(collision_points, velocity * ratio);
   } else {
     collision_time = polygon->getCollisionTime(collision_points, velocity);
@@ -561,7 +559,7 @@ bool CollisionMonitor::processApproach(
     const Velocity safe_vel = velocity * change_ratio;
 
     if (min_vel != -1.0) {
-      if (safe_vel < min_vel_sq) {
+      if (safe_vel < velocity.getMagnitude()) {
         robot_action.action_type = APPROACH;
         robot_action.req_vel.x = 0.0;
         robot_action.req_vel.y = 0.0;


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [AMRNAV-6230](https://lvserv01.logivations.com/browse/AMRNAV-6230) |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | gazebo |

---

## Description of contribution in a few bullet points

* When comparing velocity command with `min_vel_before_stop` compare with squared `min_vel_before_stop` instead, since the velocity command is also squared.
* Use `max(velocity command, min_vel_before_stop)` to project robot's movement to prevent slowly driving very close to the obstacle
* Fix comment
