### PR TITLE
disable logging to prevent spam

### DIFF
--- a/nav2_collision_monitor/src/polygon.cpp
+++ b/nav2_collision_monitor/src/polygon.cpp
@@ -523,11 +523,11 @@ Polygon::dynamicParametersCallback(
 
 void Polygon::polygonCallback(geometry_msgs::msg::PolygonStamped::ConstSharedPtr msg)
 {
-  // disable logging to prevent spam
-  // RCLCPP_INFO(
-  //   logger_,
-  //   "[%s]: Polygon shape update has been arrived",
-  //   polygon_name_.c_str());
+  // debug logging to prevent spam
+  RCLCPP_DEBUG(
+    logger_,
+    "[%s]: Polygon shape update has been arrived",
+    polygon_name_.c_str());
   updatePolygon(msg);
 }
 

--- a/nav2_collision_monitor/src/polygon.cpp
+++ b/nav2_collision_monitor/src/polygon.cpp
@@ -523,10 +523,11 @@ Polygon::dynamicParametersCallback(
 
 void Polygon::polygonCallback(geometry_msgs::msg::PolygonStamped::ConstSharedPtr msg)
 {
-  RCLCPP_INFO(
-    logger_,
-    "[%s]: Polygon shape update has been arrived",
-    polygon_name_.c_str());
+  // disable logging to prevent spam
+  // RCLCPP_INFO(
+  //   logger_,
+  //   "[%s]: Polygon shape update has been arrived",
+  //   polygon_name_.c_str());
   updatePolygon(msg);
 }
 


### PR DESCRIPTION
Disable logging of updated polygons for collision monitor which we update at 2hz.
see https://lvserv01.logivations.com/browse/AMRNAV-6400
