### PR TITLE
AMRNAV-6708 AMR7 placing pallet

### DIFF
--- a/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
+++ b/nav2_behaviors/include/nav2_behaviors/timed_behavior.hpp
@@ -236,15 +236,7 @@ protected:
 
     while (rclcpp::ok()) {
       elasped_time_ = steady_clock_.now() - start_time;
-      if (action_server_->is_cancel_requested()) {
-        RCLCPP_INFO(logger_, "Canceling %s", behavior_name_.c_str());
-        stopRobot();
-        result->total_elapsed_time = elasped_time_;
-        action_server_->terminate_all(result);
-        onActionCompletion();
-        return;
-      }
-
+      
       // TODO(orduno) #868 Enable preempting a Behavior on-the-fly without stopping
       if (action_server_->is_preempt_requested()) {
         RCLCPP_ERROR(
@@ -254,6 +246,15 @@ protected:
         stopRobot();
         result->total_elapsed_time = steady_clock_.now() - start_time;
         action_server_->terminate_current(result);
+        onActionCompletion();
+        return;
+      }
+
+      if (action_server_->is_cancel_requested()) {
+        RCLCPP_INFO(logger_, "Canceling %s", behavior_name_.c_str());
+        stopRobot();
+        result->total_elapsed_time = elasped_time_;
+        action_server_->terminate_all(result);
         onActionCompletion();
         return;
       }


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://lvserv01.logivations.com/browse/AMRNAV-6708 |
| Primary OS tested on | (Ubuntu) |
| Robotic platform tested on | (gazebo simulation) |

---

## Description of contribution in a few bullet points

Reason for change:

AMR7 placed a pallet not quite next to the pallet inside the bin leave between them too much space. We call DriveOnHeading, after 2s we fail because of Timeout msec="2000" and cancel it.

![image](https://github.com/user-attachments/assets/802a0a8f-71f0-4efc-abef-2922b5c2b23d)

After that we run another DriveOnHeading which fails because we don`t wait until previous call DriveOnHeading stops and clear our new goal. This cause this issue.

![image](https://github.com/user-attachments/assets/b8a6b51f-a605-4f68-91b5-be7af3ac9f6f)

![image](https://github.com/user-attachments/assets/bdf04a4c-7be1-4626-9034-06070c8124af)

Changes in this PR:

- first we check action_server_->is_preempt_requested() then action_server_->is_cancel_requested() in TimedBehavior





