### PR TITLE
in scope of [AMRNAV-6765]: Add precision tolerance in velocity polygons check

### DIFF
--- a/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <cmath>
 
 #include "geometry_msgs/msg/polygon_stamped.hpp"
 #include "nav2_collision_monitor/polygon.hpp"

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -223,21 +223,23 @@ void VelocityPolygon::updatePolygon(const Velocity & cmd_vel_in)
 bool VelocityPolygon::isInRange(
   const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon)
 {
+  const double epsilon = 1e-6;
+
   bool in_range =
-    (cmd_vel_in.x <= sub_polygon.linear_max_ && cmd_vel_in.x >= sub_polygon.linear_min_ &&
-    cmd_vel_in.tw <= sub_polygon.theta_max_ && cmd_vel_in.tw >= sub_polygon.theta_min_);
+    (cmd_vel_in.x <= sub_polygon.linear_max_ + epsilon && cmd_vel_in.x >= sub_polygon.linear_min_ - epsilon &&
+     cmd_vel_in.tw <= sub_polygon.theta_max_ + epsilon && cmd_vel_in.tw >= sub_polygon.theta_min_ - epsilon);
 
   if (holonomic_) {
     // Additionally check if moving direction in angle range(start -> end) for holonomic case
     const double direction = std::atan2(cmd_vel_in.y, cmd_vel_in.x);
     if (sub_polygon.direction_start_angle_ <= sub_polygon.direction_end_angle_) {
       in_range &=
-        (direction >= sub_polygon.direction_start_angle_ &&
-        direction <= sub_polygon.direction_end_angle_);
+        (direction >= sub_polygon.direction_start_angle_ - epsilon &&
+         direction <= sub_polygon.direction_end_angle_ + epsilon);
     } else {
       in_range &=
-        (direction >= sub_polygon.direction_start_angle_ ||
-        direction <= sub_polygon.direction_end_angle_);
+        (direction >= sub_polygon.direction_start_angle_ - epsilon ||
+         direction <= sub_polygon.direction_end_angle_ + epsilon);
     }
   }
 


### PR DESCRIPTION
when amr is driving with a speed close to the limits (in out case it is 1.5), some times there is a log, that current velocity is not covered by any of the velocity polygons

=> add 1e-6 precision tolerance in velocity polygons isInRanfe method

velocity can be a bit bigger then 1.5
![image](https://github.com/user-attachments/assets/e3612706-90fe-4f56-87b0-8d30083d5ad1)

