### PR TITLE
use odom as collision monitor input

### DIFF
--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -22,6 +22,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
+#include "nav_msgs/msg/odometry.hpp"
 
 #include "tf2/time.h"
 #include "tf2_ros/buffer.h"
@@ -29,7 +30,6 @@
 
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_msgs/msg/collision_monitor_state.hpp"
-
 #include "nav2_collision_monitor/types.hpp"
 #include "nav2_collision_monitor/polygon.hpp"
 #include "nav2_collision_monitor/circle.hpp"
@@ -98,6 +98,11 @@ protected:
    * @param msg Input cmd_vel message
    */
   void cmdVelInCallback(geometry_msgs::msg::Twist::ConstSharedPtr msg);
+    /**
+   * @brief Callback for input odom
+   * @param msg Input odom message
+   */
+  void odomInCallback(nav_msgs::msg::Odometry::ConstSharedPtr msg);
   /**
    * @brief Publishes output cmd_vel. If robot was stopped more than stop_pub_timeout_ seconds,
    * quit to publish 0-velocity.
@@ -114,6 +119,7 @@ protected:
    * @return True if all parameters were obtained or false in failure case
    */
   bool getParameters(
+    std::string & odom_in_topic,
     std::string & cmd_vel_in_topic,
     std::string & cmd_vel_out_topic,
     std::string & state_topic);
@@ -209,7 +215,10 @@ protected:
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_in_sub_;
   /// @brief Output cmd_vel publisher
   rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_out_pub_;
-
+  /// @brief Input odom subscriber
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_in_sub_;
+  /// @brief Last twist from odometry
+  geometry_msgs::msg::Twist last_odom_msg_;
   /// @brief CollisionMonitor state publisher
   rclcpp_lifecycle::LifecyclePublisher<nav2_msgs::msg::CollisionMonitorState>::SharedPtr
     state_pub_;
@@ -227,6 +236,8 @@ protected:
   rclcpp::Time stop_stamp_;
   /// @brief Timeout after which 0-velocity ceases to be published
   rclcpp::Duration stop_pub_timeout_;
+  /// @brief Flag to check if stop polygon is triggered
+  bool is_stop_polygon_triggered_;
 };  // class CollisionMonitor
 
 }  // namespace nav2_collision_monitor

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -31,7 +31,7 @@ namespace nav2_collision_monitor
 CollisionMonitor::CollisionMonitor(const rclcpp::NodeOptions & options)
 : nav2_util::LifecycleNode("collision_monitor", "", options),
   process_active_(false), robot_action_prev_{DO_NOTHING, {-1.0, -1.0, -1.0}, ""},
-  stop_stamp_{0, 0, get_clock()->get_clock_type()}, stop_pub_timeout_(1.0, 0.0)
+  stop_stamp_{0, 0, get_clock()->get_clock_type()}, stop_pub_timeout_(1.0, 0.0), is_stop_polygon_triggered_(false)
 {
 }
 
@@ -54,18 +54,22 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & /*state*/)
   tf_buffer_->setCreateTimerInterface(timer_interface);
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
+  std::string odom_in_topic;
   std::string cmd_vel_in_topic;
   std::string cmd_vel_out_topic;
   std::string state_topic;
 
   // Obtaining ROS parameters
-  if (!getParameters(cmd_vel_in_topic, cmd_vel_out_topic, state_topic)) {
+  if (!getParameters(odom_in_topic, cmd_vel_in_topic, cmd_vel_out_topic, state_topic)) {
     return nav2_util::CallbackReturn::FAILURE;
   }
 
   cmd_vel_in_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
     cmd_vel_in_topic, 1,
     std::bind(&CollisionMonitor::cmdVelInCallback, this, std::placeholders::_1));
+  odom_in_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
+    odom_in_topic, 1,
+    std::bind(&CollisionMonitor::odomInCallback, this, std::placeholders::_1));
   cmd_vel_out_pub_ = this->create_publisher<geometry_msgs::msg::Twist>(
     cmd_vel_out_topic, 1);
 
@@ -182,6 +186,10 @@ CollisionMonitor::on_shutdown(const rclcpp_lifecycle::State & /*state*/)
 
 void CollisionMonitor::cmdVelInCallback(geometry_msgs::msg::Twist::ConstSharedPtr msg)
 {
+  // if(!is_stop_polygon_triggered_) {
+  //   return;
+  // }
+
   // If message contains NaN or Inf, ignore
   if (!nav2_util::validateTwist(*msg)) {
     RCLCPP_ERROR(get_logger(), "Velocity message contains NaNs or Infs! Ignoring as invalid!");
@@ -189,6 +197,17 @@ void CollisionMonitor::cmdVelInCallback(geometry_msgs::msg::Twist::ConstSharedPt
   }
 
   process({msg->linear.x, msg->linear.y, msg->angular.z});
+}
+
+void CollisionMonitor::odomInCallback(nav_msgs::msg::Odometry::ConstSharedPtr msg)
+{
+  if(!nav2_util::validateTwist(msg->twist.twist)) {
+    RCLCPP_ERROR(get_logger(), "Odometry twist message contains NaNs or Infs! Ignoring as invalid!");
+    return;
+  }
+
+  last_odom_msg_ = msg->twist.twist;
+  // process({msg->twist.twist.linear.x, msg->twist.twist.linear.y, msg->twist.twist.angular.z});
 }
 
 void CollisionMonitor::publishVelocity(const Action & robot_action)
@@ -215,6 +234,7 @@ void CollisionMonitor::publishVelocity(const Action & robot_action)
 }
 
 bool CollisionMonitor::getParameters(
+  std::string & odom_in_topic,
   std::string & cmd_vel_in_topic,
   std::string & cmd_vel_out_topic,
   std::string & state_topic)
@@ -228,6 +248,9 @@ bool CollisionMonitor::getParameters(
   nav2_util::declare_parameter_if_not_declared(
     node, "cmd_vel_in_topic", rclcpp::ParameterValue("cmd_vel_raw"));
   cmd_vel_in_topic = get_parameter("cmd_vel_in_topic").as_string();
+  nav2_util::declare_parameter_if_not_declared(
+    node, "odom_in_topic", rclcpp::ParameterValue("odom"));
+  odom_in_topic = get_parameter("odom_in_topic").as_string();
   nav2_util::declare_parameter_if_not_declared(
     node, "cmd_vel_out_topic", rclcpp::ParameterValue("cmd_vel"));
   cmd_vel_out_topic = get_parameter("cmd_vel_out_topic").as_string();
@@ -462,7 +485,11 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in)
     }
 
     // Update polygon coordinates
-    polygon->updatePolygon(cmd_vel_in);
+    if(is_stop_polygon_triggered_) {
+      polygon->updatePolygon(cmd_vel_in);
+    } else {
+      polygon->updatePolygon({last_odom_msg_.linear.x, last_odom_msg_.linear.y, last_odom_msg_.angular.z});
+    }
 
     const ActionType at = polygon->getActionType();
     if (at == STOP || at == SLOWDOWN || at == LIMIT) {
@@ -477,6 +504,8 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in)
       }
     }
   }
+
+  robot_action.action_type == STOP ? is_stop_polygon_triggered_ = true : is_stop_polygon_triggered_ = false; 
 
   if (robot_action.polygon_name != robot_action_prev_.polygon_name) {
     // Report changed robot behavior


### PR DESCRIPTION
use odom to decide with polygon to use, in case STOP polygon is triggered -> odom twist.x = twist.y = 0 in this case we use the velocity_smoother_cmd_vel to choose the polygon, it is needed only once to force twist.x and twist.y to change from 0 