### PR TITLE
AMRNAV-6877: collision monitor steering angle

### DIFF
--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -23,6 +23,8 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 #include "nav_msgs/msg/odometry.hpp"
+#include "nav2_msgs/msg/velocity_polygon_pair.hpp"
+#include "nav2_msgs/msg/active_velocity_polygons.hpp"
 
 #include "tf2/time.h"
 #include "tf2_ros/buffer.h"
@@ -236,6 +238,8 @@ protected:
   rclcpp::Time stop_stamp_;
   /// @brief Timeout after which 0-velocity ceases to be published
   rclcpp::Duration stop_pub_timeout_;
+  /// @brief Active polygons publisher
+  rclcpp::Publisher<nav2_msgs::msg::ActiveVelocityPolygons>::SharedPtr active_polygons_pub_;
 };  // class CollisionMonitor
 
 }  // namespace nav2_collision_monitor

--- a/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
@@ -136,8 +136,6 @@ protected:
   // Variables
   /// @brief Flag to indicate if the robot is holonomic
   bool holonomic_;
-  // /// @brief Distance between front and rear axes
-  // double wheelbase_;
   /// @brief Steering transform name
   std::string steering_link_name_{"steering_link"};
   /// @brief Current steering angle

--- a/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
@@ -123,6 +123,12 @@ protected:
    */
   bool isInRange(const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon_param);
 
+  /**
+   * @brief Returns current steering angle based on steering_link_name_ transform
+     @return current steering angle
+   */
+  double getSteeringAngleFromTF();
+
   // Clock
   rclcpp::Clock::SharedPtr clock_;
   // Current subpolygon name
@@ -130,8 +136,12 @@ protected:
   // Variables
   /// @brief Flag to indicate if the robot is holonomic
   bool holonomic_;
-  /// @brief Distance between front and rear axes
-  double wheelbase_;
+  // /// @brief Distance between front and rear axes
+  // double wheelbase_;
+  /// @brief Steering transform name
+  std::string steering_link_name_{"steering_link"};
+  /// @brief Current steering angle
+  double current_steering_angle_;
   /// @brief Vector to store the parameters of the sub-polygon
   std::vector<SubPolygonParameter> sub_polygons_;
 };

--- a/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
@@ -23,6 +23,7 @@
 #include "nav2_collision_monitor/polygon.hpp"
 #include "nav2_collision_monitor/types.hpp"
 #include "nav2_util/lifecycle_node.hpp"
+#include "std_msgs/msg/string.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2_ros/buffer.h"
 
@@ -61,6 +62,11 @@ public:
   bool getParameters(
     std::string & /*polygon_sub_topic*/, std::string & polygon_pub_topic,
     std::string & /*footprint_topic*/) override;
+  
+  /**
+   * @brief Returns current polygon name
+   */
+  std::string getCurrentSubPolygonName() const { return current_subpolygon_name_; }
 
   /**
    * @brief Overriden updatePolygon function for VelocityPolygon
@@ -119,7 +125,8 @@ protected:
 
   // Clock
   rclcpp::Clock::SharedPtr clock_;
-
+  // Current subpolygon name
+  std::string current_subpolygon_name_;
   // Variables
   /// @brief Flag to indicate if the robot is holonomic
   bool holonomic_;
@@ -127,7 +134,7 @@ protected:
   double wheelbase_;
   /// @brief Vector to store the parameters of the sub-polygon
   std::vector<SubPolygonParameter> sub_polygons_;
-};  // class VelocityPolygon
+};
 
 }  // namespace nav2_collision_monitor
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
@@ -125,7 +125,7 @@ protected:
 
   /**
    * @brief Returns current steering angle based on steering_link_name_ transform
-     @return current steering angle
+   * @return current steering angle
    */
   double getSteeringAngleFromTF();
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
@@ -77,6 +77,8 @@ protected:
     * @param linear_max_ The maximum linear velocity
     * @param theta_min_ The minimum angular velocity
     * @param theta_max_ The maximum angular velocity
+    * @param steering_angle_min_ The minimum steering angle
+    * @param steering_angle_max_ The maxomum steering angle
     * @param direction_end_angle_ The end angle of the direction(For holonomic robot only)
     * @param direction_start_angle_ The start angle of the direction(For holonomic robot only)
     * @param slowdown_ratio_ Robot slowdown (share of its actual speed)
@@ -94,6 +96,9 @@ protected:
     double linear_max_;
     double theta_min_;
     double theta_max_;
+    double steering_angle_min_;
+    double steering_angle_max_;
+    bool use_steering_angle_;
     double direction_end_angle_;
     double direction_start_angle_;
     double slowdown_ratio_;
@@ -118,6 +123,8 @@ protected:
   // Variables
   /// @brief Flag to indicate if the robot is holonomic
   bool holonomic_;
+  /// @brief Distance between front and rear axes
+  double wheelbase_;
   /// @brief Vector to store the parameters of the sub-polygon
   std::vector<SubPolygonParameter> sub_polygons_;
 };  // class VelocityPolygon

--- a/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
@@ -123,13 +123,6 @@ protected:
    */
   bool isInRange(const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon_param);
 
-
-  // to do 
-  // double normalizeAngle(double angle);
-
-  // to do 
-  // double calculateSteeringAngle(const Velocity& cmd_vel);
-
   // Clock
   rclcpp::Clock::SharedPtr clock_;
   // Current subpolygon name

--- a/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
@@ -123,11 +123,12 @@ protected:
    */
   bool isInRange(const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon_param);
 
-  /**
-   * @brief Returns current steering angle based on steering_link_name_ transform
-   * @return current steering angle
-   */
-  double getSteeringAngleFromTF();
+
+  // to do 
+  // double normalizeAngle(double angle);
+
+  // to do 
+  // double calculateSteeringAngle(const Velocity& cmd_vel);
 
   // Clock
   rclcpp::Clock::SharedPtr clock_;
@@ -136,10 +137,10 @@ protected:
   // Variables
   /// @brief Flag to indicate if the robot is holonomic
   bool holonomic_;
-  /// @brief Steering transform name
-  std::string steering_link_name_{"steering_link"};
   /// @brief Current steering angle
   double current_steering_angle_;
+  /// @brief Distance between front and rear axes
+  double wheelbase_;
   /// @brief Vector to store the parameters of the sub-polygon
   std::vector<SubPolygonParameter> sub_polygons_;
 };

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -73,6 +73,9 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & /*state*/)
   cmd_vel_out_pub_ = this->create_publisher<geometry_msgs::msg::Twist>(
     cmd_vel_out_topic, 1);
 
+  active_polygons_pub_ = this->create_publisher<nav2_msgs::msg::ActiveVelocityPolygons>(
+    "~/active_velocity_polygons", 1);
+
   if (!state_topic.empty()) {
     state_pub_ = this->create_publisher<nav2_msgs::msg::CollisionMonitorState>(
       state_topic, 1);
@@ -470,7 +473,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in)
     collision_points_marker_pub_->publish(std::move(marker_array));
   }
 
-  const double velocity_threshold = 0.01;
+  const double velocity_threshold = 0.1;
 
   bool robot_stopped = std::abs(last_odom_msg_.linear.x) < velocity_threshold &&
                        std::abs(last_odom_msg_.linear.y) < velocity_threshold && 
@@ -487,7 +490,21 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in)
 
     // Update polygon coordinates
     if(robot_stopped) {
-      polygon->updatePolygon(cmd_vel_in);
+      // when robot is stopped we need to choose the correct polygon in the direction of where it should move
+      // so we use cmd_vel_in and scale its magnitude to pick a "slow" polygon
+      double magnitude = std::sqrt(cmd_vel_in.x * cmd_vel_in.x +
+                                 cmd_vel_in.y * cmd_vel_in.y +
+                                 cmd_vel_in.tw * cmd_vel_in.tw);
+
+    Velocity scaled_cmd_vel_in = cmd_vel_in;
+
+    if (magnitude > 0.2) {
+      double scale_factor = 0.2 / magnitude;
+      scaled_cmd_vel_in.x *= scale_factor;
+      scaled_cmd_vel_in.y *= scale_factor;
+      scaled_cmd_vel_in.tw *= scale_factor;
+    }
+    polygon->updatePolygon(scaled_cmd_vel_in);
     } else {
       polygon->updatePolygon({last_odom_msg_.linear.x, last_odom_msg_.linear.y, last_odom_msg_.angular.z});
     }
@@ -516,6 +533,19 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in)
 
   // Publish polygons for better visualization
   publishPolygons();
+
+  auto msg = std::make_unique<nav2_msgs::msg::ActiveVelocityPolygons>();
+  
+  for (const auto& polygon : polygons_) {
+    if (auto vel_polygon = std::dynamic_pointer_cast<VelocityPolygon>(polygon)) {
+      nav2_msgs::msg::VelocityPolygonPair pair;
+      pair.polygon_name = vel_polygon->getName();
+      pair.subpolygon_name = vel_polygon->getCurrentSubPolygonName();
+      msg->active_pairs.push_back(pair);
+    }
+  }
+
+  active_polygons_pub_->publish(std::move(msg));
 
   robot_action_prev_ = robot_action;
 }

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -344,10 +344,24 @@ bool VelocityPolygon::isInRange(const Velocity & cmd_vel_in, const SubPolygonPar
 
     in_range &= current_steering_angle_ <= sub_polygon.steering_angle_max_ && 
                 current_steering_angle_ >= sub_polygon.steering_angle_min_;
-    } else {
-      in_range &= cmd_vel_in.tw <= sub_polygon.theta_max_ && 
+  } else {
+    in_range &= cmd_vel_in.tw <= sub_polygon.theta_max_ && 
                   cmd_vel_in.tw >= sub_polygon.theta_min_;
+  }
+
+  if (holonomic_) {
+    // Additionally check if moving direction in angle range(start -> end) for holonomic case
+    const double direction = std::atan2(cmd_vel_in.y, cmd_vel_in.x);
+    if (sub_polygon.direction_start_angle_ <= sub_polygon.direction_end_angle_) {
+      in_range &=
+        (direction >= sub_polygon.direction_start_angle_ &&
+        direction <= sub_polygon.direction_end_angle_);
+    } else {
+      in_range &=
+        (direction >= sub_polygon.direction_start_angle_ ||
+        direction <= sub_polygon.direction_end_angle_);
     }
+  }
 
   return in_range;
 }

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -219,6 +219,8 @@ void VelocityPolygon::updatePolygon(const Velocity & cmd_vel_in)
     if (isInRange(cmd_vel_in, sub_polygon)) {
       // Set the polygon that is within the speed range
       poly_ = sub_polygon.poly_;
+      
+      current_subpolygon_name_ = sub_polygon.velocity_polygon_name_;
 
       // Update visualization polygon
       polygon_.polygon.points.clear();
@@ -240,6 +242,8 @@ void VelocityPolygon::updatePolygon(const Velocity & cmd_vel_in)
       return;
     }
   }
+
+  current_subpolygon_name_ = "none";
 
   // Log for uncovered velocity
   RCLCPP_WARN_THROTTLE(

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -293,23 +293,6 @@ void VelocityPolygon::updatePolygon(const Velocity & cmd_vel_in)
   return;
 }
 
-// double VelocityPolygon::normalizeAngle(double angle) {
-//     while (angle > M_PI) angle -= 2 * M_PI;
-//     while (angle < -M_PI) angle += 2 * M_PI;
-//     return angle;
-// }
-
-// double VelocityPolygon::calculateSteeringAngle(const Velocity& cmd_vel) {
-//     if (std::abs(cmd_vel.x) < 1e-6) {
-//         return (std::abs(cmd_vel.tw) < 1e-6) ? 
-//                0.0 : 
-//                (cmd_vel.tw > 0 ? M_PI/2 : -M_PI/2);
-//     }
-
-//     double angle = std::atan2(wheelbase_ * cmd_vel.tw, cmd_vel.x);
-//     return normalizeAngle(angle);
-// }
-
 bool VelocityPolygon::isInRange(const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon) {
   bool in_range = cmd_vel_in.x <= sub_polygon.linear_max_ && 
                   cmd_vel_in.x >= sub_polygon.linear_min_;
@@ -320,22 +303,29 @@ bool VelocityPolygon::isInRange(const Velocity & cmd_vel_in, const SubPolygonPar
                                0.0 : 
                                (cmd_vel_in.tw > 0 ? M_PI/2 : -M_PI/2);
     } else {
-      current_steering_angle_ = std::atan2(wheelbase_ * cmd_vel_in.tw, cmd_vel_in.x);
+      double angular_vel = cmd_vel_in.tw;
+      if (cmd_vel_in.x < 0) {
+        angular_vel = -angular_vel;
+      }
+
+      current_steering_angle_ = std::atan2(wheelbase_ * angular_vel, std::abs(cmd_vel_in.x));
     }
 
     RCLCPP_DEBUG(
       logger_,
-      "Calculated steering angle: %.2f (limits: %.2f to %.2f)",
+      "Calculated steering angle: %.2f (limits: %.2f to %.2f), linear_vel: %.2f, angular_vel: %.2f",
       current_steering_angle_,
       sub_polygon.steering_angle_min_,
-      sub_polygon.steering_angle_max_
+      sub_polygon.steering_angle_max_,
+      cmd_vel_in.x,
+      cmd_vel_in.tw
     );
 
     in_range &= current_steering_angle_ <= sub_polygon.steering_angle_max_ && 
                 current_steering_angle_ >= sub_polygon.steering_angle_min_;
   } else {
     in_range &= cmd_vel_in.tw <= sub_polygon.theta_max_ && 
-                  cmd_vel_in.tw >= sub_polygon.theta_min_;
+                cmd_vel_in.tw >= sub_polygon.theta_min_;
   }
 
   if (holonomic_) {

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -59,6 +59,10 @@ bool VelocityPolygon::getParameters(
       node, polygon_name_ + ".holonomic", rclcpp::ParameterValue(false));
     holonomic_ = node->get_parameter(polygon_name_ + ".holonomic").as_bool();
 
+    nav2_util::declare_parameter_if_not_declared(
+      node, polygon_name_ + ".wheelbase", rclcpp::ParameterValue(1.0));
+    wheelbase_ = node->get_parameter(polygon_name_ + ".wheelbase").as_double();
+
     for (std::string velocity_polygon_name : velocity_polygons) {
       // polygon points parameter
       std::vector<Point> poly;
@@ -164,14 +168,6 @@ bool VelocityPolygon::getParameters(
         return false;
       }
 
-      nav2_util::declare_parameter_if_not_declared(
-        node,
-        polygon_name_ + ".steering_link",
-        rclcpp::ParameterValue("steering_link")
-      );
-
-      steering_link_name_ = node->get_parameter(polygon_name_ + ".steering_link").as_string();
-
       // direction_end_angle param and direction_start_angle param
       double direction_end_angle = 0.0;
       double direction_start_angle = 0.0;
@@ -257,36 +253,6 @@ bool VelocityPolygon::getParameters(
   return true;
 }
 
-double VelocityPolygon::getSteeringAngleFromTF() {
-  geometry_msgs::msg::TransformStamped transform;
-  try {
-    transform = tf_buffer_->lookupTransform(
-      base_frame_id_,
-      steering_link_name_,
-      tf2::TimePointZero
-    );
-
-    tf2::Quaternion q(
-      transform.transform.rotation.x,
-      transform.transform.rotation.y,
-      transform.transform.rotation.z,
-      transform.transform.rotation.w
-    );
-
-    double roll, pitch, yaw;
-    tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
-
-    return yaw;
-  } catch (tf2::TransformException & ex) {
-    RCLCPP_WARN(
-      logger_,
-      "Could not get steering angle transform: %s",
-      ex.what()
-    );
-    return 0.0;
-  }
-}
-
 void VelocityPolygon::updatePolygon(const Velocity & cmd_vel_in)
 {
   for (auto & sub_polygon : sub_polygons_) {
@@ -327,16 +293,39 @@ void VelocityPolygon::updatePolygon(const Velocity & cmd_vel_in)
   return;
 }
 
+// double VelocityPolygon::normalizeAngle(double angle) {
+//     while (angle > M_PI) angle -= 2 * M_PI;
+//     while (angle < -M_PI) angle += 2 * M_PI;
+//     return angle;
+// }
+
+// double VelocityPolygon::calculateSteeringAngle(const Velocity& cmd_vel) {
+//     if (std::abs(cmd_vel.x) < 1e-6) {
+//         return (std::abs(cmd_vel.tw) < 1e-6) ? 
+//                0.0 : 
+//                (cmd_vel.tw > 0 ? M_PI/2 : -M_PI/2);
+//     }
+
+//     double angle = std::atan2(wheelbase_ * cmd_vel.tw, cmd_vel.x);
+//     return normalizeAngle(angle);
+// }
+
 bool VelocityPolygon::isInRange(const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon) {
   bool in_range = cmd_vel_in.x <= sub_polygon.linear_max_ && 
                   cmd_vel_in.x >= sub_polygon.linear_min_;
 
   if (sub_polygon.use_steering_angle_) {
-    current_steering_angle_ = getSteeringAngleFromTF();
+    if (std::abs(cmd_vel_in.x) < 1e-6) {
+      current_steering_angle_ = (std::abs(cmd_vel_in.tw) < 1e-6) ? 
+                               0.0 : 
+                               (cmd_vel_in.tw > 0 ? M_PI/2 : -M_PI/2);
+    } else {
+      current_steering_angle_ = std::atan2(wheelbase_ * cmd_vel_in.tw, cmd_vel_in.x);
+    }
 
     RCLCPP_DEBUG(
       logger_,
-      "Current steering angle: %.2f (limits: %.2f to %.2f)",
+      "Calculated steering angle: %.2f (limits: %.2f to %.2f)",
       current_steering_angle_,
       sub_polygon.steering_angle_min_,
       sub_polygon.steering_angle_max_

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -106,19 +106,19 @@ bool VelocityPolygon::getParameters(
         node, steering_min_param, rclcpp::PARAMETER_DOUBLE);
       nav2_util::declare_parameter_if_not_declared(
         node, steering_max_param, rclcpp::PARAMETER_DOUBLE);
-
-      if (node->has_parameter(steering_min_param) && node->has_parameter(steering_max_param)) {
+      steering_angle_min = node->get_parameter(steering_min_param).as_double();
+      steering_angle_max = node->get_parameter(steering_max_param).as_double();
+      
+      if (steering_angle_min != 0.0 || steering_angle_max != 0.0) {
         use_steering_angle = true;
-        steering_angle_min = node->get_parameter(steering_min_param).as_double();
-        steering_angle_max = node->get_parameter(steering_max_param).as_double();
       } else {
         nav2_util::declare_parameter_if_not_declared(node, theta_min_param, rclcpp::PARAMETER_DOUBLE);
         nav2_util::declare_parameter_if_not_declared(node, theta_max_param, rclcpp::PARAMETER_DOUBLE);
-
-        if (node->has_parameter(theta_min_param) && node->has_parameter(theta_max_param)) {
-          theta_min = node->get_parameter(theta_min_param).as_double();
-          theta_max = node->get_parameter(theta_max_param).as_double();
-        } else {
+        
+        theta_min = node->get_parameter(theta_min_param).as_double();
+        theta_max = node->get_parameter(theta_max_param).as_double();
+        
+        if (theta_min == 0.0 && theta_max == 0.0) {
           RCLCPP_ERROR(
             logger_, 
             "[%s]: Either steering_angle parameters or theta parameters must be set for %s", 

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -59,6 +59,10 @@ bool VelocityPolygon::getParameters(
       node, polygon_name_ + ".holonomic", rclcpp::ParameterValue(false));
     holonomic_ = node->get_parameter(polygon_name_ + ".holonomic").as_bool();
 
+    nav2_util::declare_parameter_if_not_declared(
+      node, polygon_name_ + ".wheelbase", rclcpp::ParameterValue(1.0));
+    wheelbase_ = node->get_parameter(polygon_name_ + ".wheelbase").as_double();
+
     for (std::string velocity_polygon_name : velocity_polygons) {
       // polygon points parameter
       std::vector<Point> poly;
@@ -86,22 +90,43 @@ bool VelocityPolygon::getParameters(
         rclcpp::PARAMETER_DOUBLE);
       linear_max = node->get_parameter(polygon_name_ + "." + velocity_polygon_name + ".linear_max")
         .as_double();
+    
+      const std::string steering_min_param = polygon_name_ + "." + velocity_polygon_name + ".steering_angle_min";
+      const std::string steering_max_param = polygon_name_ + "." + velocity_polygon_name + ".steering_angle_max";
+      const std::string theta_min_param = polygon_name_ + "." + velocity_polygon_name + ".theta_min";
+      const std::string theta_max_param = polygon_name_ + "." + velocity_polygon_name + ".theta_max";
 
-      // theta_min param
-      double theta_min;
-      nav2_util::declare_parameter_if_not_declared(
-        node, polygon_name_ + "." + velocity_polygon_name + ".theta_min",
-        rclcpp::PARAMETER_DOUBLE);
-      theta_min =
-        node->get_parameter(polygon_name_ + "." + velocity_polygon_name + ".theta_min").as_double();
+      bool use_steering_angle = false;
+      double steering_angle_min = 0.0;
+      double steering_angle_max = 0.0;
+      double theta_min = 0.0;
+      double theta_max = 0.0;
 
-      // theta_max param
-      double theta_max;
       nav2_util::declare_parameter_if_not_declared(
-        node, polygon_name_ + "." + velocity_polygon_name + ".theta_max",
-        rclcpp::PARAMETER_DOUBLE);
-      theta_max =
-        node->get_parameter(polygon_name_ + "." + velocity_polygon_name + ".theta_max").as_double();
+        node, steering_min_param, rclcpp::PARAMETER_DOUBLE);
+      nav2_util::declare_parameter_if_not_declared(
+        node, steering_max_param, rclcpp::PARAMETER_DOUBLE);
+
+      if (node->has_parameter(steering_min_param) && node->has_parameter(steering_max_param)) {
+        use_steering_angle = true;
+        steering_angle_min = node->get_parameter(steering_min_param).as_double();
+        steering_angle_max = node->get_parameter(steering_max_param).as_double();
+      } else {
+        nav2_util::declare_parameter_if_not_declared(node, theta_min_param, rclcpp::PARAMETER_DOUBLE);
+        nav2_util::declare_parameter_if_not_declared(node, theta_max_param, rclcpp::PARAMETER_DOUBLE);
+
+        if (node->has_parameter(theta_min_param) && node->has_parameter(theta_max_param)) {
+          theta_min = node->get_parameter(theta_min_param).as_double();
+          theta_max = node->get_parameter(theta_max_param).as_double();
+        } else {
+          RCLCPP_ERROR(
+            logger_, 
+            "[%s]: Either steering_angle parameters or theta parameters must be set for %s", 
+            polygon_name_.c_str(),
+            velocity_polygon_name.c_str());
+          return false;
+        }
+      }
 
       // direction_end_angle param and direction_start_angle param
       double direction_end_angle = 0.0;
@@ -170,9 +195,12 @@ bool VelocityPolygon::getParameters(
 
       SubPolygonParameter sub_polygon = {
         poly, velocity_polygon_name, linear_min, linear_max, theta_min,
-        theta_max, direction_end_angle, direction_start_angle,
+        theta_max, steering_angle_min, steering_angle_max, use_steering_angle,
+        direction_end_angle, direction_start_angle,
         slowdown_ratio, linear_limit, angular_limit, time_before_collision, simulation_time_step,
-        min_vel_before_stop};
+        min_vel_before_stop
+      };
+      
       sub_polygons_.push_back(sub_polygon);
     }
   } catch (const std::exception & ex) {
@@ -181,6 +209,7 @@ bool VelocityPolygon::getParameters(
       ex.what());
     return false;
   }
+  
   return true;
 }
 
@@ -223,9 +252,22 @@ void VelocityPolygon::updatePolygon(const Velocity & cmd_vel_in)
 bool VelocityPolygon::isInRange(
   const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon)
 {
-  bool in_range =
-    (cmd_vel_in.x <= sub_polygon.linear_max_ && cmd_vel_in.x >= sub_polygon.linear_min_ &&
-    cmd_vel_in.tw <= sub_polygon.theta_max_ && cmd_vel_in.tw >= sub_polygon.theta_min_);
+  bool in_range = cmd_vel_in.x <= sub_polygon.linear_max_ && cmd_vel_in.x >= sub_polygon.linear_min_;
+
+  if (sub_polygon.use_steering_angle_) {
+    double steering_angle = 0.0;
+    if (std::abs(cmd_vel_in.x) > 1e-6) {  
+      steering_angle = std::atan2(cmd_vel_in.tw * wheelbase_, cmd_vel_in.x);
+    } else if (std::abs(cmd_vel_in.tw) > 1e-6) {
+      steering_angle = cmd_vel_in.tw > 0 ? M_PI_2 : -M_PI_2;
+    }
+
+    in_range &= (steering_angle <= sub_polygon.steering_angle_max_ && 
+                steering_angle >= sub_polygon.steering_angle_min_);
+  } else {
+    in_range &= (cmd_vel_in.tw <= sub_polygon.theta_max_ && 
+                cmd_vel_in.tw >= sub_polygon.theta_min_);
+  }
 
   if (holonomic_) {
     // Additionally check if moving direction in angle range(start -> end) for holonomic case

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -297,6 +297,10 @@ bool VelocityPolygon::isInRange(const Velocity & cmd_vel_in, const SubPolygonPar
   bool in_range = cmd_vel_in.x <= sub_polygon.linear_max_ && 
                   cmd_vel_in.x >= sub_polygon.linear_min_;
 
+  if (!in_range) {
+    return false;
+  }
+
   if (sub_polygon.use_steering_angle_) {
     if (std::abs(cmd_vel_in.x) < 1e-6) {
       current_steering_angle_ = (std::abs(cmd_vel_in.tw) < 1e-6) ? 

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -102,30 +102,70 @@ bool VelocityPolygon::getParameters(
       double theta_min = 0.0;
       double theta_max = 0.0;
 
-      nav2_util::declare_parameter_if_not_declared(
-        node, steering_min_param, rclcpp::PARAMETER_DOUBLE);
-      nav2_util::declare_parameter_if_not_declared(
-        node, steering_max_param, rclcpp::PARAMETER_DOUBLE);
-      steering_angle_min = node->get_parameter(steering_min_param).as_double();
-      steering_angle_max = node->get_parameter(steering_max_param).as_double();
-      
-      if (steering_angle_min != 0.0 || steering_angle_max != 0.0) {
-        use_steering_angle = true;
-      } else {
-        nav2_util::declare_parameter_if_not_declared(node, theta_min_param, rclcpp::PARAMETER_DOUBLE);
-        nav2_util::declare_parameter_if_not_declared(node, theta_max_param, rclcpp::PARAMETER_DOUBLE);
-        
-        theta_min = node->get_parameter(theta_min_param).as_double();
-        theta_max = node->get_parameter(theta_max_param).as_double();
-        
-        if (theta_min == 0.0 && theta_max == 0.0) {
-          RCLCPP_ERROR(
-            logger_, 
-            "[%s]: Either steering_angle parameters or theta parameters must be set for %s", 
-            polygon_name_.c_str(),
-            velocity_polygon_name.c_str());
-          return false;
+      bool has_steering_params = false;
+      bool has_theta_params = false;
+
+      try {
+        nav2_util::declare_parameter_if_not_declared(
+          node, steering_min_param, rclcpp::PARAMETER_DOUBLE);
+        nav2_util::declare_parameter_if_not_declared(
+          node, steering_max_param, rclcpp::PARAMETER_DOUBLE);
+
+        steering_angle_min = node->get_parameter(steering_min_param).as_double();
+        steering_angle_max = node->get_parameter(steering_max_param).as_double();
+        has_steering_params = true;
+      } catch (const rclcpp::exceptions::ParameterNotDeclaredException &) {
+        RCLCPP_DEBUG(logger_, "steering_angle parameters not found, will check theta parameters");
+      } catch (const rclcpp::exceptions::ParameterUninitializedException &) {
+        RCLCPP_DEBUG(logger_, "steering_angle parameters not initialized");
+      }
+
+      if (!has_steering_params) {
+        try {
+          nav2_util::declare_parameter_if_not_declared(
+            node, theta_min_param, rclcpp::PARAMETER_DOUBLE);
+          nav2_util::declare_parameter_if_not_declared(
+            node, theta_max_param, rclcpp::PARAMETER_DOUBLE);
+
+          theta_min = node->get_parameter(theta_min_param).as_double();
+          theta_max = node->get_parameter(theta_max_param).as_double();
+          has_theta_params = true;
+        } catch (const rclcpp::exceptions::ParameterNotDeclaredException &) {
+          RCLCPP_DEBUG(logger_, "Theta parameters not found");
+        } catch (const rclcpp::exceptions::ParameterUninitializedException &) {
+          RCLCPP_DEBUG(logger_, "Theta parameters not initialized");
         }
+      }
+
+      if (has_steering_params) {
+        use_steering_angle = true;
+        RCLCPP_INFO(
+          logger_, 
+          "[%s]: Using steering_angle parameters for %s (min: %f, max: %f)", 
+          polygon_name_.c_str(),
+          velocity_polygon_name.c_str(),
+          steering_angle_min,
+          steering_angle_max
+        );
+      } else if (has_theta_params) {
+        use_steering_angle = false;
+        RCLCPP_INFO(
+          logger_, 
+          "[%s]: Using theta parameters for %s (min: %f, max: %f)", 
+          polygon_name_.c_str(),
+          velocity_polygon_name.c_str(),
+          theta_min,
+          theta_max
+        );
+      } else {
+        RCLCPP_ERROR(
+          logger_, 
+          "[%s]: Neither steering_angle parameters nor theta parameters are set for %s", 
+          polygon_name_.c_str(),
+          velocity_polygon_name.c_str()
+        );
+        
+        return false;
       }
 
       // direction_end_angle param and direction_start_angle param

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -276,7 +276,7 @@ double VelocityPolygon::getSteeringAngleFromTF() {
     double roll, pitch, yaw;
     tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
 
-    return yaw;  // This is your steering angle
+    return yaw;
   } catch (tf2::TransformException & ex) {
     RCLCPP_WARN(
       logger_,

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -59,10 +59,6 @@ bool VelocityPolygon::getParameters(
       node, polygon_name_ + ".holonomic", rclcpp::ParameterValue(false));
     holonomic_ = node->get_parameter(polygon_name_ + ".holonomic").as_bool();
 
-    nav2_util::declare_parameter_if_not_declared(
-      node, polygon_name_ + ".wheelbase", rclcpp::ParameterValue(1.0));
-    wheelbase_ = node->get_parameter(polygon_name_ + ".wheelbase").as_double();
-
     for (std::string velocity_polygon_name : velocity_polygons) {
       // polygon points parameter
       std::vector<Point> poly;
@@ -168,6 +164,14 @@ bool VelocityPolygon::getParameters(
         return false;
       }
 
+      nav2_util::declare_parameter_if_not_declared(
+        node,
+        polygon_name_ + ".steering_link",
+        rclcpp::ParameterValue("steering_link")
+      );
+
+      steering_link_name_ = node->get_parameter(polygon_name_ + ".steering_link").as_string();
+
       // direction_end_angle param and direction_start_angle param
       double direction_end_angle = 0.0;
       double direction_start_angle = 0.0;
@@ -253,6 +257,36 @@ bool VelocityPolygon::getParameters(
   return true;
 }
 
+double VelocityPolygon::getSteeringAngleFromTF() {
+  geometry_msgs::msg::TransformStamped transform;
+  try {
+    transform = tf_buffer_->lookupTransform(
+      base_frame_id_,
+      steering_link_name_,
+      tf2::TimePointZero
+    );
+
+    tf2::Quaternion q(
+      transform.transform.rotation.x,
+      transform.transform.rotation.y,
+      transform.transform.rotation.z,
+      transform.transform.rotation.w
+    );
+
+    double roll, pitch, yaw;
+    tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
+
+    return yaw;  // This is your steering angle
+  } catch (tf2::TransformException & ex) {
+    RCLCPP_WARN(
+      logger_,
+      "Could not get steering angle transform: %s",
+      ex.what()
+    );
+    return 0.0;
+  }
+}
+
 void VelocityPolygon::updatePolygon(const Velocity & cmd_vel_in)
 {
   for (auto & sub_polygon : sub_polygons_) {
@@ -293,39 +327,27 @@ void VelocityPolygon::updatePolygon(const Velocity & cmd_vel_in)
   return;
 }
 
-bool VelocityPolygon::isInRange(
-  const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon)
-{
-  bool in_range = cmd_vel_in.x <= sub_polygon.linear_max_ && cmd_vel_in.x >= sub_polygon.linear_min_;
+bool VelocityPolygon::isInRange(const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon) {
+  bool in_range = cmd_vel_in.x <= sub_polygon.linear_max_ && 
+                  cmd_vel_in.x >= sub_polygon.linear_min_;
 
   if (sub_polygon.use_steering_angle_) {
-    double steering_angle = 0.0;
-    if (std::abs(cmd_vel_in.x) > 1e-6) {  
-      steering_angle = std::atan2(cmd_vel_in.tw * wheelbase_, cmd_vel_in.x);
-    } else if (std::abs(cmd_vel_in.tw) > 1e-6) {
-      steering_angle = cmd_vel_in.tw > 0 ? M_PI_2 : -M_PI_2;
-    }
+    current_steering_angle_ = getSteeringAngleFromTF();
 
-    in_range &= (steering_angle <= sub_polygon.steering_angle_max_ && 
-                steering_angle >= sub_polygon.steering_angle_min_);
-  } else {
-    in_range &= (cmd_vel_in.tw <= sub_polygon.theta_max_ && 
-                cmd_vel_in.tw >= sub_polygon.theta_min_);
-  }
+    RCLCPP_DEBUG(
+      logger_,
+      "Current steering angle: %.2f (limits: %.2f to %.2f)",
+      current_steering_angle_,
+      sub_polygon.steering_angle_min_,
+      sub_polygon.steering_angle_max_
+    );
 
-  if (holonomic_) {
-    // Additionally check if moving direction in angle range(start -> end) for holonomic case
-    const double direction = std::atan2(cmd_vel_in.y, cmd_vel_in.x);
-    if (sub_polygon.direction_start_angle_ <= sub_polygon.direction_end_angle_) {
-      in_range &=
-        (direction >= sub_polygon.direction_start_angle_ &&
-        direction <= sub_polygon.direction_end_angle_);
+    in_range &= current_steering_angle_ <= sub_polygon.steering_angle_max_ && 
+                current_steering_angle_ >= sub_polygon.steering_angle_min_;
     } else {
-      in_range &=
-        (direction >= sub_polygon.direction_start_angle_ ||
-        direction <= sub_polygon.direction_end_angle_);
+      in_range &= cmd_vel_in.tw <= sub_polygon.theta_max_ && 
+                  cmd_vel_in.tw >= sub_polygon.theta_min_;
     }
-  }
 
   return in_range;
 }

--- a/nav2_msgs/CMakeLists.txt
+++ b/nav2_msgs/CMakeLists.txt
@@ -30,6 +30,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Particle.msg"
   "msg/ParticleCloud.msg"
   "msg/MissedWaypoint.msg"
+  "msg/VelocityPolygonPair.msg"
+  "msg/ActiveVelocityPolygons.msg"
   "srv/GetCostmap.srv"
   "srv/IsPathValid.srv"
   "srv/ClearCostmapExceptRegion.srv"

--- a/nav2_msgs/msg/ActiveVelocityPolygons.msg
+++ b/nav2_msgs/msg/ActiveVelocityPolygons.msg
@@ -1,0 +1,1 @@
+VelocityPolygonPair[] active_pairs

--- a/nav2_msgs/msg/VelocityPolygonPair.msg
+++ b/nav2_msgs/msg/VelocityPolygonPair.msg
@@ -1,0 +1,2 @@
+string polygon_name
+string subpolygon_name


### PR DESCRIPTION
https://lvserv01.logivations.com/browse/AMRNAV-6877

add the option to specify steering_angle_min and steering_angle_max in collision monitor velocity polygons. If that is specified, it should be used instead of the thetas 

