### PR TITLE
AMRNAV-6759 StraightLinePath goal succeeds immediatly

### DIFF
--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -646,6 +646,8 @@ void ControllerServer::setPlannerPath(const nav_msgs::msg::Path & path)
 
   end_pose_ = path.poses.back();
   end_pose_.header.frame_id = path.header.frame_id;
+  end_pose_.header.stamp.sec = path.header.stamp.sec;
+  end_pose_.header.stamp.nanosec = path.header.stamp.nanosec;
   goal_checkers_[current_goal_checker_]->reset();
 
   RCLCPP_DEBUG(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

### Basic Info

| Info                  | Please fill out this column               |
| --------------------- | ----------------------------------------- |
| Platform tested on    | Gazebo  |
| Related documentation |                                           |
| Ticket                |    https://lvserv01.logivations.com/browse/AMRNAV-6759   |

### Description of contribution

Reason for change:

In the Behavior Tree, using CreateStraightLinePathToGoal results in a path being planned, but being immediatly approved as "Goal reached" before the amr can start moving. This problem does not appear when using the typical ComputePathToPose planning with the Smac planner.
<!--
* Describe what is wrong with the current implementation
* Share background thinking on the changes
-->

Changes in this PR:

- fix time stamp in end_pose_

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in tracking.properties
* If breaking change - was it added to https://coda.io/d/Autonomous-Mobile-Robot_da82dg_s4hc/Release-notes_suOpf?search=#_luotl ?
-->

Result:
CreateStraightLinePathToGoal works correct

<!--
put link to rosbag here, or upload screencast / video
-->
