### PR TITLE
AMRNAV-6916 Goal checker: Check for x and y separately

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_reached_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_reached_condition.hpp
@@ -77,7 +77,7 @@ public:
       BT::InputPort<std::string>("global_frame", std::string("map"), "Global frame"),
       BT::InputPort<double>("x_goal_tolerance", std::numeric_limits<double>::infinity(), "x goal tolerance"),
       BT::InputPort<double>("y_goal_tolerance", std::numeric_limits<double>::infinity(), "y goal tolerance"),
-      BT::InputPort<double>("xy_goal_tolerance", 0.1, "xy goal tolerance"),
+      BT::InputPort<double>("xy_goal_tolerance", std::numeric_limits<double>::infinity(), "xy goal tolerance"),
       BT::InputPort<double>("yaw_goal_tolerance", 0.1, "yaw goal tolerance"),
       BT::InputPort<std::string>("robot_base_frame", std::string("base_link"), "Robot base frame")
     };

--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_reached_condition.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/condition/goal_reached_condition.hpp
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <memory>
+#include <limits>
 
 #include "rclcpp/rclcpp.hpp"
 #include "behaviortree_cpp_v3/condition_node.h"
@@ -74,6 +75,8 @@ public:
     return {
       BT::InputPort<geometry_msgs::msg::PoseStamped>("goal", "Destination"),
       BT::InputPort<std::string>("global_frame", std::string("map"), "Global frame"),
+      BT::InputPort<double>("x_goal_tolerance", std::numeric_limits<double>::infinity(), "x goal tolerance"),
+      BT::InputPort<double>("y_goal_tolerance", std::numeric_limits<double>::infinity(), "y goal tolerance"),
       BT::InputPort<double>("xy_goal_tolerance", 0.1, "xy goal tolerance"),
       BT::InputPort<double>("yaw_goal_tolerance", 0.1, "yaw goal tolerance"),
       BT::InputPort<std::string>("robot_base_frame", std::string("base_link"), "Robot base frame")
@@ -93,6 +96,8 @@ private:
 
   bool initialized_;
   double goal_reached_tol_;
+  double goal_reached_tol_x_;
+  double goal_reached_tol_y_ ;
   double goal_reached_tol_yaw_;
   std::string global_frame_;
   std::string robot_base_frame_;

--- a/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
@@ -97,8 +97,8 @@ bool GoalReachedCondition::isGoalReached()
   tf2::Transform current_pose_in_goal_frame = goal_frame_transform.inverse() * tf2::Transform(tf2::Quaternion(current_pose.pose.orientation.x, current_pose.pose.orientation.y, current_pose.pose.orientation.z, current_pose.pose.orientation.w), 
   tf2::Vector3(current_pose.pose.position.x, current_pose.pose.position.y, current_pose.pose.position.z));
 
-  double x_in_goal_frame = current_pose_in_goal_frame.getOrigin().x();
-  double y_in_goal_frame = current_pose_in_goal_frame.getOrigin().y();
+  double x_in_goal_frame = fabs(current_pose_in_goal_frame.getOrigin().x());
+  double y_in_goal_frame = fabs(current_pose_in_goal_frame.getOrigin().y());
 
   RCLCPP_INFO(node_->get_logger(), "current_pose_in_goal_frame x: %f, y: %f", x_in_goal_frame, y_in_goal_frame);
 
@@ -107,9 +107,9 @@ bool GoalReachedCondition::isGoalReached()
   double dangle = fabs(angles::shortest_angular_distance(goal_yaw, current_yaw));
 
   // Check conditions for x, y, and xy tolerances
-  bool within_xy_tolerance = (x_in_goal_frame * x_in_goal_frame + y_in_goal_frame * y_in_goal_frame) <= (goal_reached_tol_ * goal_reached_tol_);
-  bool within_x_tolerance = fabs(x_in_goal_frame) <= goal_reached_tol_x_;
-  bool within_y_tolerance = fabs(y_in_goal_frame) <= goal_reached_tol_y_;
+  bool within_xy_tolerance = ((x_in_goal_frame <= goal_reached_tol_) && (y_in_goal_frame <= goal_reached_tol_));
+  bool within_x_tolerance = x_in_goal_frame <= goal_reached_tol_x_;
+  bool within_y_tolerance = y_in_goal_frame <= goal_reached_tol_y_;
   bool within_yaw_tolerance = dangle <= goal_reached_tol_yaw_;
 
   return within_xy_tolerance && within_x_tolerance && within_y_tolerance && within_yaw_tolerance;

--- a/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
@@ -89,16 +89,27 @@ bool GoalReachedCondition::isGoalReached()
   geometry_msgs::msg::PoseStamped goal;
   getInput("goal", goal);
 
+  // Transform to goal frame
+  tf2::Transform goal_frame_transform;
+  goal_frame_transform.setOrigin(tf2::Vector3(goal.pose.position.x, goal.pose.position.y, 0.0));
+  goal_frame_transform.setRotation(tf2::Quaternion(goal.pose.orientation.x, goal.pose.orientation.y, goal.pose.orientation.z, goal.pose.orientation.w));
+
+  tf2::Transform current_pose_in_goal_frame = goal_frame_transform.inverse() * tf2::Transform(tf2::Quaternion(current_pose.pose.orientation.x, current_pose.pose.orientation.y, current_pose.pose.orientation.z, current_pose.pose.orientation.w), 
+  tf2::Vector3(current_pose.pose.position.x, current_pose.pose.position.y, current_pose.pose.position.z));
+
+  double x_in_goal_frame = current_pose_in_goal_frame.getOrigin().x();
+  double y_in_goal_frame = current_pose_in_goal_frame.getOrigin().y();
+
+  RCLCPP_INFO(node_->get_logger(), "current_pose_in_goal_frame x: %f, y: %f", x_in_goal_frame, y_in_goal_frame);
+
   double current_yaw = tf2::getYaw(current_pose.pose.orientation);
   double goal_yaw = tf2::getYaw(goal.pose.orientation);
   double dangle = fabs(angles::shortest_angular_distance(goal_yaw, current_yaw));
-  double dx = goal.pose.position.x - current_pose.pose.position.x;
-  double dy = goal.pose.position.y - current_pose.pose.position.y;
 
   // Check conditions for x, y, and xy tolerances
-  bool within_xy_tolerance = (dx * dx + dy * dy) <= (goal_reached_tol_ * goal_reached_tol_);
-  bool within_x_tolerance = fabs(dx) <= goal_reached_tol_x_;
-  bool within_y_tolerance = fabs(dy) <= goal_reached_tol_y_;
+  bool within_xy_tolerance = (x_in_goal_frame * x_in_goal_frame + y_in_goal_frame * y_in_goal_frame) <= (goal_reached_tol_ * goal_reached_tol_);
+  bool within_x_tolerance = fabs(x_in_goal_frame) <= goal_reached_tol_x_;
+  bool within_y_tolerance = fabs(y_in_goal_frame) <= goal_reached_tol_y_;
   bool within_yaw_tolerance = dangle <= goal_reached_tol_yaw_;
 
   return within_xy_tolerance && within_x_tolerance && within_y_tolerance && within_yaw_tolerance;

--- a/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
@@ -65,6 +65,8 @@ void GoalReachedCondition::initialize()
   getInput("global_frame", global_frame_);
   getInput("robot_base_frame", robot_base_frame_);
   getInput("xy_goal_tolerance", goal_reached_tol_);
+  getInput("x_goal_tolerance", goal_reached_tol_x_);
+  getInput("y_goal_tolerance", goal_reached_tol_y_);
   getInput("yaw_goal_tolerance", goal_reached_tol_yaw_);
 
   tf_ = config().blackboard->get<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
@@ -93,8 +95,13 @@ bool GoalReachedCondition::isGoalReached()
   double dx = goal.pose.position.x - current_pose.pose.position.x;
   double dy = goal.pose.position.y - current_pose.pose.position.y;
 
-  return (dx * dx + dy * dy) <= (goal_reached_tol_ * goal_reached_tol_) &&
-         dangle <= goal_reached_tol_yaw_;
+  // Check conditions for x, y, and xy tolerances
+  bool within_xy_tolerance = (dx * dx + dy * dy) <= (goal_reached_tol_ * goal_reached_tol_);
+  bool within_x_tolerance = fabs(dx) <= goal_reached_tol_x_;
+  bool within_y_tolerance = fabs(dy) <= goal_reached_tol_y_;
+  bool within_yaw_tolerance = dangle <= goal_reached_tol_yaw_;
+
+  return within_xy_tolerance && within_x_tolerance && within_y_tolerance && within_yaw_tolerance;
 }
 
 }  // namespace nav2_behavior_tree

--- a/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
@@ -85,10 +85,6 @@ bool GoalReachedCondition::isGoalReached()
     RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
     return false;
   }
-  RCLCPP_INFO(node_->get_logger(), "current_pose x: %f, y: %f", current_pose.pose.orientation.x, current_pose.pose.orientation.y);
-
-  // RCLCPP_INFO(node_->get_logger(), "x_goal_tolerance %f", goal_reached_tol_x_);
-  // RCLCPP_INFO(node_->get_logger(), "y_goal_tolerance %f", goal_reached_tol_y_);
   geometry_msgs::msg::PoseStamped goal;
   getInput("goal", goal);
 
@@ -110,7 +106,7 @@ bool GoalReachedCondition::isGoalReached()
   double dangle = fabs(angles::shortest_angular_distance(goal_yaw, current_yaw));
 
   // Check conditions for x, y, and xy tolerances
-  bool within_xy_tolerance = (x_in_goal_frame * x_in_goal_frame + y_in_goal_frame * y_in_goal_frame) <= (goal_reached_tol_ * goal_reached_tol_);    //  ((x_in_goal_frame <= goal_reached_tol_) && (y_in_goal_frame <= goal_reached_tol_));
+  bool within_xy_tolerance = (x_in_goal_frame * x_in_goal_frame + y_in_goal_frame * y_in_goal_frame) <= (goal_reached_tol_ * goal_reached_tol_);  
   bool within_x_tolerance = x_in_goal_frame <= goal_reached_tol_x_;
   bool within_y_tolerance = y_in_goal_frame <= goal_reached_tol_y_;
   bool within_yaw_tolerance = dangle <= goal_reached_tol_yaw_;

--- a/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
+++ b/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
@@ -85,7 +85,10 @@ bool GoalReachedCondition::isGoalReached()
     RCLCPP_DEBUG(node_->get_logger(), "Current robot pose is not available.");
     return false;
   }
+  RCLCPP_INFO(node_->get_logger(), "current_pose x: %f, y: %f", current_pose.pose.orientation.x, current_pose.pose.orientation.y);
 
+  // RCLCPP_INFO(node_->get_logger(), "x_goal_tolerance %f", goal_reached_tol_x_);
+  // RCLCPP_INFO(node_->get_logger(), "y_goal_tolerance %f", goal_reached_tol_y_);
   geometry_msgs::msg::PoseStamped goal;
   getInput("goal", goal);
 
@@ -107,7 +110,7 @@ bool GoalReachedCondition::isGoalReached()
   double dangle = fabs(angles::shortest_angular_distance(goal_yaw, current_yaw));
 
   // Check conditions for x, y, and xy tolerances
-  bool within_xy_tolerance = ((x_in_goal_frame <= goal_reached_tol_) && (y_in_goal_frame <= goal_reached_tol_));
+  bool within_xy_tolerance = (x_in_goal_frame * x_in_goal_frame + y_in_goal_frame * y_in_goal_frame) <= (goal_reached_tol_ * goal_reached_tol_);    //  ((x_in_goal_frame <= goal_reached_tol_) && (y_in_goal_frame <= goal_reached_tol_));
   bool within_x_tolerance = x_in_goal_frame <= goal_reached_tol_x_;
   bool within_y_tolerance = y_in_goal_frame <= goal_reached_tol_y_;
   bool within_yaw_tolerance = dangle <= goal_reached_tol_yaw_;

--- a/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
@@ -243,22 +243,39 @@ TEST_F(GoalReachedConditionTestFixture, test_tolerance_cases)
     EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);  
   }
  
-  // {
-  //   pose.position.x = 1.5;
-  //   pose.position.y = 1.5;  
+  {
+    pose.position.x = 1.5;
+    pose.position.y = 1.5;  
 
-  //   std::string xml_txt =
-  //     R"(
-  //     <root main_tree_to_execute = "MainTree" >
-  //       <BehaviorTree ID="MainTree">
-  //         <GoalReached goal="{goal}" xy_goal_tolerance="1.5" />
-  //       </BehaviorTree>
-  //     </root>)";
-  //   SetUp(xml_txt, 0.0, 0.0);
-  //   transform_handler_->updateRobotPose(pose);
-  //   std::this_thread::sleep_for(500ms);
-  //   EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);  
-  // }
+    std::string xml_txt =
+      R"(
+      <root main_tree_to_execute = "MainTree" >
+        <BehaviorTree ID="MainTree">
+          <GoalReached goal="{goal}" xy_goal_tolerance="2.25" />
+        </BehaviorTree>
+      </root>)";
+    SetUp(xml_txt, 0.0, 0.0);
+    transform_handler_->updateRobotPose(pose);
+    std::this_thread::sleep_for(500ms);
+    EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);  
+  }
+
+  {
+    pose.position.x = 1.5;
+    pose.position.y = 1.5;  
+
+    std::string xml_txt =
+      R"(
+      <root main_tree_to_execute = "MainTree" >
+        <BehaviorTree ID="MainTree">
+          <GoalReached goal="{goal}" xy_goal_tolerance="1.25" />
+        </BehaviorTree>
+      </root>)";
+    SetUp(xml_txt, 0.0, 0.0);
+    transform_handler_->updateRobotPose(pose);
+    std::this_thread::sleep_for(500ms);
+    EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE);  
+  }
   
 }
 

--- a/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
@@ -30,7 +30,7 @@ using namespace std::chrono_literals;  // NOLINT
 class GoalReachedConditionTestFixture : public nav2_behavior_tree::BehaviorTreeTestFixture
 {
 public:
-  void SetUp(const std::string &xml_txt)
+  void SetUp(const std::string &xml_txt, const double &goal_x, const double &goal_y)
   {
     if (!node_->has_parameter("transform_tolerance")) {
       node_->declare_parameter("transform_tolerance", rclcpp::ParameterValue{0.1});
@@ -39,8 +39,8 @@ public:
     geometry_msgs::msg::PoseStamped goal;
     goal.header.stamp = node_->now();
     goal.header.frame_id = "map";
-    goal.pose.position.x = 0.0;
-    goal.pose.position.y = 0.0;
+    goal.pose.position.x = goal_x;
+    goal.pose.position.y = goal_y; 
     config_->blackboard->set("goal", goal);
     
     if(!registered_type_) {
@@ -70,11 +70,11 @@ TEST_F(GoalReachedConditionTestFixture, test_behavior)
     R"(
     <root main_tree_to_execute = "MainTree" >
       <BehaviorTree ID="MainTree">
-          <GoalReached goal="{goal}" xy_goal_tolerance="0.1" x_goal_tolerance="0.1" y_goal_tolerance="0.1"/>
+          <GoalReached goal="{goal}" y_goal_tolerance="0.1"/>
       </BehaviorTree>
     </root>)";
 
-  SetUp(xml_txt);
+  SetUp(xml_txt, 1.0, 1.0);
   EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE);
 
   geometry_msgs::msg::Pose pose;
@@ -108,7 +108,6 @@ TEST_F(GoalReachedConditionTestFixture, test_tolerance_cases)
   geometry_msgs::msg::Pose pose;
   pose.position.x = 1.0;
   pose.position.y = 0.0;
-  
   {
     std::string xml_txt =
       R"(
@@ -117,7 +116,7 @@ TEST_F(GoalReachedConditionTestFixture, test_tolerance_cases)
           <GoalReached goal="{goal}" x_goal_tolerance="0.3" y_goal_tolerance="2.0" />
         </BehaviorTree>
       </root>)";
-    SetUp(xml_txt);
+    SetUp(xml_txt, 0.0, 0.0);
     transform_handler_->updateRobotPose(pose);
     std::this_thread::sleep_for(500ms);
     EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE);
@@ -131,7 +130,7 @@ TEST_F(GoalReachedConditionTestFixture, test_tolerance_cases)
           <GoalReached goal="{goal}" x_goal_tolerance="1.3" y_goal_tolerance="0.5" />
         </BehaviorTree>
       </root>)";
-    SetUp(xml_txt);
+    SetUp(xml_txt, 0.0, 0.0);
     transform_handler_->updateRobotPose(pose);
     std::this_thread::sleep_for(500ms);
     EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);
@@ -145,7 +144,7 @@ TEST_F(GoalReachedConditionTestFixture, test_tolerance_cases)
           <GoalReached goal="{goal}" x_goal_tolerance="0.3" y_goal_tolerance="0.3" xy_goal_tolerance="0.3" />
         </BehaviorTree>
       </root>)";
-    SetUp(xml_txt);
+    SetUp(xml_txt, 0.0, 0.0);
     transform_handler_->updateRobotPose(pose);
     std::this_thread::sleep_for(500ms);
     EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE);
@@ -156,10 +155,10 @@ TEST_F(GoalReachedConditionTestFixture, test_tolerance_cases)
       R"(
       <root main_tree_to_execute = "MainTree" >
         <BehaviorTree ID="MainTree">
-          <GoalReached goal="{goal}" x_goal_tolerance="0.3" y_goal_tolerance="0.3" xy_goal_tolerance="1.3" />
+          <GoalReached goal="{goal}" y_goal_tolerance="0.3" xy_goal_tolerance="1.3" />
         </BehaviorTree>
       </root>)";
-    SetUp(xml_txt);
+    SetUp(xml_txt, 0.0, 0.0);
     transform_handler_->updateRobotPose(pose);
     std::this_thread::sleep_for(500ms);
     EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);
@@ -173,7 +172,7 @@ TEST_F(GoalReachedConditionTestFixture, test_tolerance_cases)
           <GoalReached goal="{goal}" xy_goal_tolerance="1.3" />
         </BehaviorTree>
       </root>)";
-    SetUp(xml_txt);
+    SetUp(xml_txt, 0.0, 0.0);
     transform_handler_->updateRobotPose(pose);
     std::this_thread::sleep_for(500ms);
     EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);
@@ -187,13 +186,81 @@ TEST_F(GoalReachedConditionTestFixture, test_tolerance_cases)
           <GoalReached goal="{goal}" xy_goal_tolerance="0.3" />
         </BehaviorTree>
       </root>)";
-    SetUp(xml_txt);
+    SetUp(xml_txt, 0.0, 0.0);
     transform_handler_->updateRobotPose(pose);
     std::this_thread::sleep_for(500ms);
     EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE);
   }
-}
 
+  {
+    pose.position.x = 0.4;
+    pose.position.y = 0.0;
+
+    std::string xml_txt =
+      R"(
+      <root main_tree_to_execute = "MainTree" >
+        <BehaviorTree ID="MainTree">
+          <GoalReached goal="{goal}" x_goal_tolerance="0.3" y_goal_tolerance="2.0" />
+        </BehaviorTree>
+      </root>)";
+    SetUp(xml_txt, 0.0, 0.0);
+    transform_handler_->updateRobotPose(pose);
+    std::this_thread::sleep_for(500ms);
+    EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE); 
+  } 
+
+  {
+    pose.position.x = 0.2;
+    pose.position.y = 0.0;
+
+    std::string xml_txt =
+      R"(
+      <root main_tree_to_execute = "MainTree" >
+        <BehaviorTree ID="MainTree">
+          <GoalReached goal="{goal}" x_goal_tolerance="0.3" y_goal_tolerance="2.0" />
+        </BehaviorTree>
+      </root>)";
+    SetUp(xml_txt, 0.0, 0.0);
+    transform_handler_->updateRobotPose(pose);
+    std::this_thread::sleep_for(500ms);
+    EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS); 
+  }
+
+  {
+    pose.position.x = 0.0;
+    pose.position.y = 0.0;
+
+    std::string xml_txt =
+      R"(
+      <root main_tree_to_execute = "MainTree" >
+        <BehaviorTree ID="MainTree">
+          <GoalReached goal="{goal}" x_goal_tolerance="0.3" y_goal_tolerance="0.3" />
+        </BehaviorTree>
+      </root>)";
+    SetUp(xml_txt, 0.0, 0.0);
+    transform_handler_->updateRobotPose(pose);
+    std::this_thread::sleep_for(500ms);
+    EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);  
+  }
+ 
+  // {
+  //   pose.position.x = 1.5;
+  //   pose.position.y = 1.5;  
+
+  //   std::string xml_txt =
+  //     R"(
+  //     <root main_tree_to_execute = "MainTree" >
+  //       <BehaviorTree ID="MainTree">
+  //         <GoalReached goal="{goal}" xy_goal_tolerance="1.5" />
+  //       </BehaviorTree>
+  //     </root>)";
+  //   SetUp(xml_txt, 0.0, 0.0);
+  //   transform_handler_->updateRobotPose(pose);
+  //   std::this_thread::sleep_for(500ms);
+  //   EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);  
+  // }
+  
+}
 
 int main(int argc, char ** argv)
 {

--- a/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
@@ -33,6 +33,7 @@ public:
   void SetUp()
   {
     node_->declare_parameter("transform_tolerance", rclcpp::ParameterValue{0.1});
+    // node_->declare_parameter("goal_reached_tol_", rclcpp::ParameterValue{0.1});
 
     geometry_msgs::msg::PoseStamped goal;
     goal.header.stamp = node_->now();
@@ -45,7 +46,7 @@ public:
       R"(
       <root main_tree_to_execute = "MainTree" >
         <BehaviorTree ID="MainTree">
-            <GoalReached goal="{goal}" />
+            <GoalReached goal="{goal}" xy_goal_tolerance="0.1" />
         </BehaviorTree>
       </root>)";
 

--- a/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
@@ -45,7 +45,7 @@ public:
       R"(
       <root main_tree_to_execute = "MainTree" >
         <BehaviorTree ID="MainTree">
-            <GoalReached goal="{goal}" xy_goal_tolerance="0.1" />
+            <GoalReached goal="{goal}" xy_goal_tolerance="0.1" x_goal_tolerance="0.1" y_goal_tolerance="0.1"/>
         </BehaviorTree>
       </root>)";
 

--- a/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
@@ -33,7 +33,6 @@ public:
   void SetUp()
   {
     node_->declare_parameter("transform_tolerance", rclcpp::ParameterValue{0.1});
-    // node_->declare_parameter("goal_reached_tol_", rclcpp::ParameterValue{0.1});
 
     geometry_msgs::msg::PoseStamped goal;
     goal.header.stamp = node_->now();

--- a/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
@@ -106,6 +106,8 @@ TEST_F(GoalReachedConditionTestFixture, test_behavior)
 TEST_F(GoalReachedConditionTestFixture, test_tolerance_cases)
 {
   geometry_msgs::msg::Pose pose;
+  pose.position.x = 1.0;
+  pose.position.y = 0.0;
   
   {
     std::string xml_txt =

--- a/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
+++ b/nav2_behavior_tree/test/plugins/condition/test_goal_reached.cpp
@@ -30,26 +30,24 @@ using namespace std::chrono_literals;  // NOLINT
 class GoalReachedConditionTestFixture : public nav2_behavior_tree::BehaviorTreeTestFixture
 {
 public:
-  void SetUp()
+  void SetUp(const std::string &xml_txt)
   {
-    node_->declare_parameter("transform_tolerance", rclcpp::ParameterValue{0.1});
+    if (!node_->has_parameter("transform_tolerance")) {
+      node_->declare_parameter("transform_tolerance", rclcpp::ParameterValue{0.1});
+    }
 
     geometry_msgs::msg::PoseStamped goal;
     goal.header.stamp = node_->now();
     goal.header.frame_id = "map";
-    goal.pose.position.x = 1.0;
-    goal.pose.position.y = 1.0;
+    goal.pose.position.x = 0.0;
+    goal.pose.position.y = 0.0;
     config_->blackboard->set("goal", goal);
-
-    std::string xml_txt =
-      R"(
-      <root main_tree_to_execute = "MainTree" >
-        <BehaviorTree ID="MainTree">
-            <GoalReached goal="{goal}" xy_goal_tolerance="0.1" x_goal_tolerance="0.1" y_goal_tolerance="0.1"/>
-        </BehaviorTree>
-      </root>)";
-
-    factory_->registerNodeType<nav2_behavior_tree::GoalReachedCondition>("GoalReached");
+    
+    if(!registered_type_) {
+      registered_type_ = true;
+      factory_->registerNodeType<nav2_behavior_tree::GoalReachedCondition>("GoalReached");
+    }
+    
     tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
   }
 
@@ -59,13 +57,24 @@ public:
   }
 
 protected:
+  static bool registered_type_; 
   static std::shared_ptr<BT::Tree> tree_;
 };
 
 std::shared_ptr<BT::Tree> GoalReachedConditionTestFixture::tree_ = nullptr;
+bool GoalReachedConditionTestFixture::registered_type_ = false;
 
 TEST_F(GoalReachedConditionTestFixture, test_behavior)
 {
+  std::string xml_txt =
+    R"(
+    <root main_tree_to_execute = "MainTree" >
+      <BehaviorTree ID="MainTree">
+          <GoalReached goal="{goal}" xy_goal_tolerance="0.1" x_goal_tolerance="0.1" y_goal_tolerance="0.1"/>
+      </BehaviorTree>
+    </root>)";
+
+  SetUp(xml_txt);
   EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE);
 
   geometry_msgs::msg::Pose pose;
@@ -93,6 +102,96 @@ TEST_F(GoalReachedConditionTestFixture, test_behavior)
   std::this_thread::sleep_for(500ms);
   EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);
 }
+
+TEST_F(GoalReachedConditionTestFixture, test_tolerance_cases)
+{
+  geometry_msgs::msg::Pose pose;
+  
+  {
+    std::string xml_txt =
+      R"(
+      <root main_tree_to_execute = "MainTree" >
+        <BehaviorTree ID="MainTree">
+          <GoalReached goal="{goal}" x_goal_tolerance="0.3" y_goal_tolerance="2.0" />
+        </BehaviorTree>
+      </root>)";
+    SetUp(xml_txt);
+    transform_handler_->updateRobotPose(pose);
+    std::this_thread::sleep_for(500ms);
+    EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE);
+  }
+
+  {
+    std::string xml_txt =
+      R"(
+      <root main_tree_to_execute = "MainTree" >
+        <BehaviorTree ID="MainTree">
+          <GoalReached goal="{goal}" x_goal_tolerance="1.3" y_goal_tolerance="0.5" />
+        </BehaviorTree>
+      </root>)";
+    SetUp(xml_txt);
+    transform_handler_->updateRobotPose(pose);
+    std::this_thread::sleep_for(500ms);
+    EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);
+  }
+
+  {
+    std::string xml_txt =
+      R"(
+      <root main_tree_to_execute = "MainTree" >
+        <BehaviorTree ID="MainTree">
+          <GoalReached goal="{goal}" x_goal_tolerance="0.3" y_goal_tolerance="0.3" xy_goal_tolerance="0.3" />
+        </BehaviorTree>
+      </root>)";
+    SetUp(xml_txt);
+    transform_handler_->updateRobotPose(pose);
+    std::this_thread::sleep_for(500ms);
+    EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE);
+  }
+
+  {
+    std::string xml_txt =
+      R"(
+      <root main_tree_to_execute = "MainTree" >
+        <BehaviorTree ID="MainTree">
+          <GoalReached goal="{goal}" x_goal_tolerance="0.3" y_goal_tolerance="0.3" xy_goal_tolerance="1.3" />
+        </BehaviorTree>
+      </root>)";
+    SetUp(xml_txt);
+    transform_handler_->updateRobotPose(pose);
+    std::this_thread::sleep_for(500ms);
+    EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);
+  }
+
+  {
+    std::string xml_txt =
+      R"(
+      <root main_tree_to_execute = "MainTree" >
+        <BehaviorTree ID="MainTree">
+          <GoalReached goal="{goal}" xy_goal_tolerance="1.3" />
+        </BehaviorTree>
+      </root>)";
+    SetUp(xml_txt);
+    transform_handler_->updateRobotPose(pose);
+    std::this_thread::sleep_for(500ms);
+    EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::SUCCESS);
+  }
+
+  {
+    std::string xml_txt =
+      R"(
+      <root main_tree_to_execute = "MainTree" >
+        <BehaviorTree ID="MainTree">
+          <GoalReached goal="{goal}" xy_goal_tolerance="0.3" />
+        </BehaviorTree>
+      </root>)";
+    SetUp(xml_txt);
+    transform_handler_->updateRobotPose(pose);
+    std::this_thread::sleep_for(500ms);
+    EXPECT_EQ(tree_->tickRoot(), BT::NodeStatus::FAILURE);
+  }
+}
+
 
 int main(int argc, char ** argv)
 {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

### Basic Info

| Info                  | Please fill out this column               |
| --------------------- | ----------------------------------------- |
| Platform tested on    | Gazebo |
| Related documentation |                                           |
| Ticket                |  https://lvserv01.logivations.com/browse/AMRNAV-6916        |

### Description of contribution

Reason for change:
There is often a tradeoff while reaching goals: We want the AMR to drive as close as it can to the goal, without oscillating close to it. The AMR can easily adjust its x-coordinate compared to the goal by driving forward or backwards.
However, it cannot drive sideways, so it cannot correct sideways error easily. Instead, then it has to drive forward, turn, and drive backwards again.
Thus: We want to split the checker to check directions individually in the goal frame. Currently one can already pass "yaw". Please add options to pass "x" and "y" as well. Then

if "x" or "y" is defined, also check these values
if "xy" is not defined in the BT node, use "infinite" by default.


<!--
* Describe what is wrong with the current implementation
* Share background thinking on the changes
-->

Changes in this PR:


<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in tracking.properties
* If breaking change - was it added to https://coda.io/d/Autonomous-Mobile-Robot_da82dg_s4hc/Release-notes_suOpf?search=#_luotl ?
-->

Result:
x and y are checked separately

<!--
put link to rosbag here, or upload screencast / video
-->
