### PR TITLE
AMRNAV-6980: Adapt goal checkers for separate x and y checks

### DIFF
--- a/nav2_controller/include/nav2_controller/plugins/simple_goal_checker.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/simple_goal_checker.hpp
@@ -76,6 +76,7 @@ protected:
   bool stateful_, check_xy_;
   // Cached squared xy_goal_tolerance_
   double xy_goal_tolerance_sq_;
+  double x_goal_tolerance_, y_goal_tolerance_;
   // Dynamic parameters handler
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr dyn_params_handler_;
   std::string plugin_name_;

--- a/nav2_controller/plugins/simple_goal_checker.cpp
+++ b/nav2_controller/plugins/simple_goal_checker.cpp
@@ -57,7 +57,9 @@ SimpleGoalChecker::SimpleGoalChecker()
   yaw_goal_tolerance_(0.25),
   stateful_(true),
   check_xy_(true),
-  xy_goal_tolerance_sq_(0.0625)
+  xy_goal_tolerance_sq_(0.0625),
+  x_goal_tolerance_(std::numeric_limits<double>::infinity()),
+  y_goal_tolerance_(std::numeric_limits<double>::infinity())
 {
 }
 
@@ -71,6 +73,12 @@ void SimpleGoalChecker::initialize(
 
   nav2_util::declare_parameter_if_not_declared(
     node,
+    plugin_name + ".x_goal_tolerance",  rclcpp::ParameterValue(std::numeric_limits<double>::infinity()));
+  nav2_util::declare_parameter_if_not_declared(
+    node,
+    plugin_name + ".y_goal_tolerance",  rclcpp::ParameterValue(std::numeric_limits<double>::infinity()));
+  nav2_util::declare_parameter_if_not_declared(
+    node,
     plugin_name + ".xy_goal_tolerance", rclcpp::ParameterValue(0.25));
   nav2_util::declare_parameter_if_not_declared(
     node,
@@ -79,6 +87,8 @@ void SimpleGoalChecker::initialize(
     node,
     plugin_name + ".stateful", rclcpp::ParameterValue(true));
 
+  node->get_parameter(plugin_name + ".x_goal_tolerance", x_goal_tolerance_);
+  node->get_parameter(plugin_name + ".y_goal_tolerance", y_goal_tolerance_);
   node->get_parameter(plugin_name + ".xy_goal_tolerance", xy_goal_tolerance_);
   node->get_parameter(plugin_name + ".yaw_goal_tolerance", yaw_goal_tolerance_);
   node->get_parameter(plugin_name + ".stateful", stateful_);
@@ -99,6 +109,23 @@ bool SimpleGoalChecker::isGoalReached(
   const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
   const geometry_msgs::msg::Twist &)
 {
+  double x_in_goal_frame = 0.0;
+  double y_in_goal_frame = 0.0;
+
+  if(std::isfinite(x_goal_tolerance_) || std::isfinite(y_goal_tolerance_)){
+    // Transform to goal frame
+    tf2::Transform goal_frame_transform;
+    goal_frame_transform.setOrigin(tf2::Vector3(goal_pose.position.x, goal_pose.position.y, 0.0));
+    goal_frame_transform.setRotation(tf2::Quaternion(goal_pose.orientation.x, goal_pose.orientation.y, goal_pose.orientation.z, goal_pose.orientation.w));
+
+    tf2::Transform query_pose_in_goal_frame = goal_frame_transform.inverse() * 
+      tf2::Transform(tf2::Quaternion(query_pose.orientation.x, query_pose.orientation.y, query_pose.orientation.z, query_pose.orientation.w),
+                    tf2::Vector3(query_pose.position.x, query_pose.position.y, query_pose.position.z));
+
+    x_in_goal_frame = fabs(query_pose_in_goal_frame.getOrigin().x());
+    y_in_goal_frame = fabs(query_pose_in_goal_frame.getOrigin().y());
+  }
+
   if (check_xy_) {
     double dx = query_pose.position.x - goal_pose.position.x,
       dy = query_pose.position.y - goal_pose.position.y;
@@ -114,7 +141,11 @@ bool SimpleGoalChecker::isGoalReached(
   double dyaw = angles::shortest_angular_distance(
     tf2::getYaw(query_pose.orientation),
     tf2::getYaw(goal_pose.orientation));
-  return fabs(dyaw) < yaw_goal_tolerance_;
+
+  bool within_x_tolerance = x_in_goal_frame <= x_goal_tolerance_;
+  bool within_y_tolerance = y_in_goal_frame <= y_goal_tolerance_;
+
+  return (fabs(dyaw) < yaw_goal_tolerance_) && within_x_tolerance && within_y_tolerance;
 }
 
 bool SimpleGoalChecker::getTolerances(
@@ -154,6 +185,10 @@ SimpleGoalChecker::dynamicParametersCallback(std::vector<rclcpp::Parameter> para
         xy_goal_tolerance_sq_ = xy_goal_tolerance_ * xy_goal_tolerance_;
       } else if (name == plugin_name_ + ".yaw_goal_tolerance") {
         yaw_goal_tolerance_ = parameter.as_double();
+      } else if (name == plugin_name_ + ".x_goal_tolerance") {
+        x_goal_tolerance_ = parameter.as_double();
+      } else if (name == plugin_name_ + ".y_goal_tolerance") {
+        y_goal_tolerance_ = parameter.as_double();
       }
     } else if (type == ParameterType::PARAMETER_BOOL) {
       if (name == plugin_name_ + ".stateful") {

--- a/nav2_controller/plugins/stopped_goal_checker.cpp
+++ b/nav2_controller/plugins/stopped_goal_checker.cpp
@@ -84,13 +84,33 @@ bool StoppedGoalChecker::isGoalReached(
   const geometry_msgs::msg::Pose & query_pose, const geometry_msgs::msg::Pose & goal_pose,
   const geometry_msgs::msg::Twist & velocity)
 {
+  double x_in_goal_frame = 0.0;
+  double y_in_goal_frame = 0.0;
+
+  if(std::isfinite(x_goal_tolerance_) || std::isfinite(y_goal_tolerance_)){
+    // Transform to goal frame
+    tf2::Transform goal_frame_transform;
+    goal_frame_transform.setOrigin(tf2::Vector3(goal_pose.position.x, goal_pose.position.y, 0.0));
+    goal_frame_transform.setRotation(tf2::Quaternion(goal_pose.orientation.x, goal_pose.orientation.y, goal_pose.orientation.z, goal_pose.orientation.w));
+
+    tf2::Transform query_pose_in_goal_frame = goal_frame_transform.inverse() * 
+      tf2::Transform(tf2::Quaternion(query_pose.orientation.x, query_pose.orientation.y, query_pose.orientation.z, query_pose.orientation.w),
+                    tf2::Vector3(query_pose.position.x, query_pose.position.y, query_pose.position.z));
+
+    x_in_goal_frame = fabs(query_pose_in_goal_frame.getOrigin().x());
+    y_in_goal_frame = fabs(query_pose_in_goal_frame.getOrigin().y());
+  }
+
   bool ret = SimpleGoalChecker::isGoalReached(query_pose, goal_pose, velocity);
   if (!ret) {
     return ret;
   }
 
+  bool within_x_tolerance = x_in_goal_frame <= x_goal_tolerance_;
+  bool within_y_tolerance = y_in_goal_frame <= y_goal_tolerance_;
+
   return fabs(velocity.angular.z) <= rot_stopped_velocity_ &&
-         hypot(velocity.linear.x, velocity.linear.y) <= trans_stopped_velocity_;
+         hypot(velocity.linear.x, velocity.linear.y) <= trans_stopped_velocity_ && within_x_tolerance && within_y_tolerance;
 }
 
 bool StoppedGoalChecker::getTolerances(


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

### Basic Info

| Info                  | Please fill out this column               |
| --------------------- | ----------------------------------------- |
| Platform tested on    | Gazebo |
| Related documentation |                                           |
| Ticket                | https://lvserv01.logivations.com/browse/AMRNAV-6980     |

### Description of contribution

Reason for change:
Please adapt the goal checkers to also offer the (optional) check in x and y direction in goal frame. Please adapt both StoppedGoalChecker and SimpleGoalChecker.


<!--
* Describe what is wrong with the current implementation
* Share background thinking on the changes
-->

Changes in this PR:
-  check in x and y direction

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in tracking.properties
* If breaking change - was it added to https://coda.io/d/Autonomous-Mobile-Robot_da82dg_s4hc/Release-notes_suOpf?search=#_luotl ?
-->

Result:
x and y are checked separately

<!--
put link to rosbag here, or upload screencast / video
-->
