### PR TITLE
AMRNAV-6977: Add option recover_before_failing to RecoveryNode

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/plugins/control/recovery_node.hpp
@@ -56,7 +56,8 @@ public:
   static BT::PortsList providedPorts()
   {
     return {
-      BT::InputPort<int>("number_of_retries", 1, "Number of retries")
+      BT::InputPort<int>("number_of_retries", 1, "Number of retries"),
+      BT::InputPort<bool>("recover_before_failing", false,"Run the recovery part, and then fail anyway"),
     };
   }
 
@@ -64,6 +65,7 @@ private:
   unsigned int current_child_idx_;
   unsigned int number_of_retries_;
   unsigned int retry_count_;
+  bool recover_before_failing_;
 
   /**
    * @brief The main override required by a BT action

--- a/nav2_behavior_tree/plugins/control/recovery_node.cpp
+++ b/nav2_behavior_tree/plugins/control/recovery_node.cpp
@@ -66,9 +66,14 @@ BT::NodeStatus RecoveryNode::tick()
               ControlNode::haltChild(0);
               current_child_idx_ = 1; 
               TreeNode * recovery_child_node = children_nodes_[current_child_idx_];
-              recovery_child_node->executeTick();
-              halt();
-              return BT::NodeStatus::FAILURE;
+              BT::NodeStatus recovery_status = recovery_child_node->executeTick();
+              if (recovery_status == BT::NodeStatus::RUNNING) {
+                // Recovery is still in progress, so wait
+                return BT::NodeStatus::RUNNING;
+              } else {
+                halt();
+                return BT::NodeStatus::FAILURE;
+              } 
             } else {
               // reset node and return failure when max retries has been exceeded
               halt();

--- a/nav2_behavior_tree/plugins/control/recovery_node.cpp
+++ b/nav2_behavior_tree/plugins/control/recovery_node.cpp
@@ -61,15 +61,18 @@ BT::NodeStatus RecoveryNode::tick()
               ControlNode::haltChild(0);
               current_child_idx_++;
               break;
+            } else if (recover_before_failing_) {
+              // Run recovery before failing
+              ControlNode::haltChild(0);
+              current_child_idx_ = 1; 
+              TreeNode * recovery_child_node = children_nodes_[current_child_idx_];
+              recovery_child_node->executeTick();
+              halt();
+              return BT::NodeStatus::FAILURE;
             } else {
-              if (recover_before_failing_) {
-                ControlNode::haltChild(0);
-                current_child_idx_++;
-                break;
-              } else {
-                halt();
-                return BT::NodeStatus::FAILURE;
-              }
+              // reset node and return failure when max retries has been exceeded
+              halt();
+              return BT::NodeStatus::FAILURE;
             }
           }
 

--- a/nav2_behavior_tree/plugins/control/recovery_node.cpp
+++ b/nav2_behavior_tree/plugins/control/recovery_node.cpp
@@ -24,13 +24,15 @@ RecoveryNode::RecoveryNode(
 : BT::ControlNode::ControlNode(name, conf),
   current_child_idx_(0),
   number_of_retries_(1),
-  retry_count_(0)
+  retry_count_(0),
+  recover_before_failing_(false)
 {
 }
 
 BT::NodeStatus RecoveryNode::tick()
 {
   getInput("number_of_retries", number_of_retries_);
+  getInput("recover_before_failing", recover_before_failing_);
   const unsigned children_count = children_nodes_.size();
 
   if (children_count != 2) {
@@ -59,6 +61,8 @@ BT::NodeStatus RecoveryNode::tick()
               ControlNode::haltChild(0);
               current_child_idx_++;
               break;
+            } else if (recover_before_failing_) {
+              current_child_idx_++; // Execute recovery before failing
             } else {
               // reset node and return failure when max retries has been exceeded
               halt();

--- a/nav2_behavior_tree/plugins/control/recovery_node.cpp
+++ b/nav2_behavior_tree/plugins/control/recovery_node.cpp
@@ -57,14 +57,13 @@ BT::NodeStatus RecoveryNode::tick()
         case BT::NodeStatus::FAILURE:
           {
             if (retry_count_ < number_of_retries_) {
-              // halt first child and tick second child in next iteration
               ControlNode::haltChild(0);
               current_child_idx_++;
-              break;
+              break; 
             } else if (recover_before_failing_) {
               current_child_idx_++; // Execute recovery before failing
+              break;
             } else {
-              // reset node and return failure when max retries has been exceeded
               halt();
               return BT::NodeStatus::FAILURE;
             }

--- a/nav2_behavior_tree/plugins/control/recovery_node.cpp
+++ b/nav2_behavior_tree/plugins/control/recovery_node.cpp
@@ -57,15 +57,19 @@ BT::NodeStatus RecoveryNode::tick()
         case BT::NodeStatus::FAILURE:
           {
             if (retry_count_ < number_of_retries_) {
+              // halt first child and tick second child in next iteration
               ControlNode::haltChild(0);
               current_child_idx_++;
-              break; 
-            } else if (recover_before_failing_) {
-              current_child_idx_++; // Execute recovery before failing
               break;
             } else {
-              halt();
-              return BT::NodeStatus::FAILURE;
+              if (recover_before_failing_) {
+                ControlNode::haltChild(0);
+                current_child_idx_++;
+                break;
+              } else {
+                halt();
+                return BT::NodeStatus::FAILURE;
+              }
             }
           }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

### Basic Info

| Info                  | Please fill out this column               |
| --------------------- | ----------------------------------------- |
| Platform tested on    | Webots / Gazebo / Simple Simulation / AMR |
| Related documentation |                                           |
| Ticket                |  https://lvserv01.logivations.com/browse/AMRNAV-6977     |

### Description of contribution

Reason for change:
Use case: RecoveryNode is often used to try sth, and "clean up" if the try failed before retrying. 

Now, if the number_of_retries is exhausted, the recovery is not performed. 

Add some option "recover_before_failing". It should instead still run the recovery part, and then fail anyway.

<!--
* Describe what is wrong with the current implementation
* Share background thinking on the changes
-->

Changes in this PR:

1) add recover_before_failing InputPort to RecoveryNode that is false by default

2) RecoveryNode do it's normal operation until number_of_retries is exhausted

3) if number_of_retries is exhausted -> then we check if recover_before_failing is true

4) if recover_before_failing is true then we run recovery child

5) After recovery part already finished to run -> RecoveryNode should fail anyways as child is not SUCCESS

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in tracking.properties
* If breaking change - was it added to https://coda.io/d/Autonomous-Mobile-Robot_da82dg_s4hc/Release-notes_suOpf?search=#_luotl ?
-->

Result:

Recovery node recover before failing if recover_before_failing is set to true

<!--
put link to rosbag here, or upload screencast / video
-->
