### PR TITLE
collision_points publish only on STOP

### DIFF
--- a/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/circle.hpp
@@ -67,6 +67,13 @@ public:
   int getPointsInside(const std::vector<Point> & points) const override;
 
   /**
+   * @brief Gets points inside given polygon
+   * @param points Input array of points to be checked
+   * @param points_inside Output array of points inside polygon
+   */
+  void getPointsInside(const std::vector<Point> & points, std::vector<Point>& points_inside) const override;
+
+  /**
    * @brief Specifies that the shape is always set for a circle object
    */
   bool isShapeSet() override {return true;}

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -199,6 +199,8 @@ protected:
    */
   void publishPolygons() const;
 
+  void publishCollisionPoints(const std::vector<Point>& collision_points) const;
+
   // ----- Variables -----
 
   /// @brief TF buffer

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -199,6 +199,10 @@ protected:
    */
   void publishPolygons() const;
 
+   /**
+   * @brief Collision points publishing routine. Made for visualization.
+   * @param collision_points collision points to publish
+   */
   void publishCollisionPoints(const std::vector<Point>& collision_points) const;
 
   // ----- Variables -----

--- a/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/polygon.hpp
@@ -159,6 +159,13 @@ public:
   virtual int getPointsInside(const std::vector<Point> & points) const;
 
   /**
+   * @brief Gets points inside given polygon
+   * @param points Input array of points to be checked
+   * @param points_inside Output array of points inside polygon
+   */
+  virtual void getPointsInside(const std::vector<Point> & points, std::vector<Point>& points_inside) const;
+
+  /**
    * @brief Obtains estimated (simulated) time before a collision.
    * Applicable for APPROACH model.
    * @param collision_points Array of 2D obstacle points

--- a/nav2_collision_monitor/src/circle.cpp
+++ b/nav2_collision_monitor/src/circle.cpp
@@ -70,6 +70,15 @@ int Circle::getPointsInside(const std::vector<Point> & points) const
   return num;
 }
 
+void Circle::getPointsInside(const std::vector<Point> & points, std::vector<Point>& points_inside) const
+{
+    for (Point point : points) {
+    if (point.x * point.x + point.y * point.y < radius_squared_) {
+      points_inside.push_back(point);
+    }
+  }
+}
+
 bool Circle::getParameters(
   std::string & polygon_sub_topic,
   std::string & polygon_pub_topic,

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -446,33 +446,6 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in)
     }
   }
 
-  if (collision_points_marker_pub_->get_subscription_count() > 0) {
-    // visualize collision points with markers
-    auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
-    visualization_msgs::msg::Marker marker;
-    marker.header.frame_id = get_parameter("base_frame_id").as_string();
-    marker.header.stamp = rclcpp::Time(0, 0);
-    marker.ns = "collision_points";
-    marker.id = 0;
-    marker.type = visualization_msgs::msg::Marker::POINTS;
-    marker.action = visualization_msgs::msg::Marker::ADD;
-    marker.scale.x = 0.02;
-    marker.scale.y = 0.02;
-    marker.color.r = 1.0;
-    marker.color.a = 1.0;
-    marker.lifetime = rclcpp::Duration(0, 0);
-
-    for (const auto & point : collision_points) {
-      geometry_msgs::msg::Point p;
-      p.x = point.x;
-      p.y = point.y;
-      p.z = 0.0;
-      marker.points.push_back(p);
-    }
-    marker_array->markers.push_back(marker);
-    collision_points_marker_pub_->publish(std::move(marker_array));
-  }
-
   const double velocity_threshold = 0.1;
 
   bool robot_stopped = std::abs(last_odom_msg_.linear.x) < velocity_threshold &&
@@ -560,8 +533,14 @@ bool CollisionMonitor::processStopSlowdownLimit(
     return false;
   }
 
-  if (polygon->getPointsInside(collision_points) >= polygon->getMinPoints()) {
-    if (polygon->getActionType() == STOP) {
+  std::vector<Point> collision_points_inside_polygon;
+  polygon->getPointsInside(collision_points, collision_points_inside_polygon);
+
+  if (static_cast<int>(collision_points_inside_polygon.size()) >= polygon->getMinPoints()) {
+    if (polygon->getActionType() == STOP) { 
+      
+      publishCollisionPoints(collision_points_inside_polygon);
+
       // Setting up zero velocity for STOP model
       robot_action.polygon_name = polygon->getName();
       robot_action.action_type = STOP;
@@ -706,6 +685,36 @@ void CollisionMonitor::publishPolygons() const
     if (polygon->getEnabled()) {
       polygon->publish();
     }
+  }
+}
+
+void CollisionMonitor::publishCollisionPoints(const std::vector<Point> & collision_points) const
+{
+  if (collision_points_marker_pub_->get_subscription_count() > 0) {
+      // visualize collision points with markers
+      auto marker_array = std::make_unique<visualization_msgs::msg::MarkerArray>();
+      visualization_msgs::msg::Marker marker;
+      marker.header.frame_id = get_parameter("base_frame_id").as_string();
+      marker.header.stamp = rclcpp::Time(0, 0);
+      marker.ns = "collision_points";
+      marker.id = 0;
+      marker.type = visualization_msgs::msg::Marker::POINTS;
+      marker.action = visualization_msgs::msg::Marker::ADD;
+      marker.scale.x = 0.02;
+      marker.scale.y = 0.02;
+      marker.color.r = 1.0;
+      marker.color.a = 1.0;
+      marker.lifetime = rclcpp::Duration(0, 0);
+
+      for (const auto & point : collision_points) {
+        geometry_msgs::msg::Point p;
+        p.x = point.x;
+        p.y = point.y;
+        p.z = 0.0;
+        marker.points.push_back(p);
+      }
+      marker_array->markers.push_back(marker);
+      collision_points_marker_pub_->publish(std::move(marker_array));
   }
 }
 

--- a/nav2_collision_monitor/src/polygon.cpp
+++ b/nav2_collision_monitor/src/polygon.cpp
@@ -255,6 +255,15 @@ int Polygon::getPointsInside(const std::vector<Point> & points) const
   return num;
 }
 
+void Polygon::getPointsInside(const std::vector<Point> & points, std::vector<Point>& points_inside) const
+{
+  for (const Point & point : points) {
+    if (isPointInside(point)) {
+      points_inside.push_back(point);
+    }
+  }
+}
+
 double Polygon::getCollisionTime(
   const std::vector<Point> & collision_points,
   const Velocity & velocity) const


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Platform tested on	| Webots / Gazebo / Simple Simulation / AMR |
| Related Documentation|  |
| Ticket |  |

---
## Description of contribution

This PR modifies the way `collision_points` are published to ensure they are only published when they stop the AMR from moving. If they do not cause the AMR to stop, no collision points are published.  

### Reason for change:

Previously, collision points were published continuously, even when they were not affecting the AMR’s movement. This caused unnecessary processing and potential confusion in data interpretation.  

### Changes in this PR:

* Updated the logic in `collision_monitor_node.cpp` to publish `collision_points` only when they stop the AMR.  
* Added `getPointsInside(const std::vector<Point> & points, std::vector<Point>& points_inside)` in `Polygon` and overrode it in `Circle`. This method determines points inside the polygon.  
* Introduced the `publishCollisionPoints` method in `collision_monitor_node.h` to handle point publishing.  

### Result:

* Reduced unnecessary publishing of `collision_points`, improving efficiency.  
* More meaningful collision data, as only relevant points are published.  
* Improved maintainability with clearer separation of concerns in `collision_monitor_node.h` and `.cpp`.  