### PR TITLE
Add lidar e-stop prevention in collision monitor

### DIFF
--- a/nav2_collision_monitor/README.md
+++ b/nav2_collision_monitor/README.md
@@ -97,3 +97,51 @@ The zones around the robot and the data sources are the same as for the Collisio
 Detailed configuration parameters, their description and how to setup a Collision Detector could be found at its [Configuration Guide](https://docs.nav2.org/configuration/packages/collision_monitor/configuring-collision-detector-node.html).
 
 The `CollisionMonitor` node makes use of a [nav2_util::TwistSubscriber](../nav2_util/README.md#twist-publisher-and-twist-subscriber-for-commanded-velocities).
+
+
+### Lidar estop prevention
+
+We use this with a safety lidar with e-stop zones depending on speed and steering angle. We want to avoid hitting such a zone.
+Thus, the collision monitor must ensure to limit the speed and steering angle so that the field chosen by
+the lidar is not intersecting with any lidar points (that would trigger an estop).
+
+During field set creation, we also generate corresponding velocity polygons. They are about 50% larger than the corresponding
+e-stop zone. example. Note that linear speed is for the steering wheel, not the baselink
+
+forward_straight_mid_3:
+  points: # polygon here
+  linear_min: 0.5
+  linear_max: 0.7
+  steering_angle_min: -0.20944 # -12 degrees in radians
+  steering_angle_max: 0.20944 # 12 degrees in radians
+  linear_limit: 0.49 # steering wheel speed, not base link speed
+
+So - if we are between 0.5 and 0.7m/s, and hit that warning field, we must reduce our speed to *below* that bracket - because there is an obstacle in the polygon,
+which, if we approach it further, would trigger an estop.0
+Once we are at 0.49, we will be in another zone with a smaller field on lidar side. Thus, the velocity polygon is also slower. If we keep approaching the obstacle, we would slow down further.
+If the obstacle e.g. moves with us or is on the side, we can keep that speed.
+
+### Step 1 Normal collision monitor with velocity polygon
+
+### Step 2: Steering validation
+If speed goes through zero (so sign(target speed) <> sign (current speed)) :
+
+* if abs(current speed) > Low threshold → keep steering angle (we must anyway just slow down asap)
+* if abs(current speed) < low threshold → allow steering
+
+else:
+
+1. check if both abs(target) and abs(current speed) are < lower threshold. If yes → done
+2. check if target angle is in same bucket as current angle. If yes →
+  1. if yes → if abs(target speed) > abs(current speed), also check next faster bucket, if in collision, limit speed to current bucket → then done
+  2. if no → determine the direction of steering and the subsequent bucket from current angle
+3. in new bucket, determine max speed / valid bucket
+  1. start at fastest possible bucket (bucket for max (current speed, target speed)). If that is in collision, go down until the slowest one is found. that one we call “valid” bucket
+  2. if the fastest possible bucket is not in collision → done
+4. now the AMR must decelerate to enter the valid bucket. Thus
+  1. limit steering angle at the boundary of current bucket
+  2. limit speed to max speed of valid bucket
+
+→ done
+
+After some iterations, the current speed will be in valid bucket → AMR will  be allowed to steer, as it will fall into case 3b

--- a/nav2_collision_monitor/README.md
+++ b/nav2_collision_monitor/README.md
@@ -105,9 +105,15 @@ We use this with a safety lidar with e-stop zones depending on speed and steerin
 Thus, the collision monitor must ensure to limit the speed and steering angle so that the field chosen by
 the lidar is not intersecting with any lidar points (that would trigger an estop).
 
-During field set creation, we also generate corresponding velocity polygons. They are about 50% larger than the corresponding
-e-stop zone. example. Note that linear speed is for the steering wheel, not the baselink
+#### Terminology
 
+* **Bucket**: a steering angle range (e.g. -12° to 12°). A bucket groups multiple fields that share the same angle range.
+* **Field**: a specific combination of steering angle bucket and velocity range. Each field corresponds to one `SubPolygonParameter` / velocity polygon entry.
+
+During field set creation, we also generate corresponding velocity polygons. They are about 50% larger than the corresponding
+e-stop zone. Example. Note that linear speed is for the steering wheel, not the baselink.
+
+```yaml
 forward_straight_mid_3:
   points: # polygon here
   linear_min: 0.5
@@ -115,34 +121,36 @@ forward_straight_mid_3:
   steering_angle_min: -0.20944 # -12 degrees in radians
   steering_angle_max: 0.20944 # 12 degrees in radians
   linear_limit: 0.49 # steering wheel speed, not base link speed
+```
 
-So - if we are between 0.5 and 0.7m/s, and hit that warning field, we must reduce our speed to *below* that bracket - because there is an obstacle in the polygon,
-which, if we approach it further, would trigger an estop.0
-Once we are at 0.49, we will be in another zone with a smaller field on lidar side. Thus, the velocity polygon is also slower. If we keep approaching the obstacle, we would slow down further.
+Here, the **bucket** is the angle range [-12°, 12°]. The **field** is that bucket combined with the speed range [0.5, 0.7].
+
+So - if we are between 0.5 and 0.7 m/s, and hit that warning field, we must reduce our speed to *below* that field - because there is an obstacle in the polygon,
+which, if we approach it further, would trigger an estop.
+Once we are at 0.49, we will be in another field with a smaller polygon on the lidar side. Thus, the velocity polygon is also smaller. If we keep approaching the obstacle, we would slow down further.
 If the obstacle e.g. moves with us or is on the side, we can keep that speed.
 
-### Step 1 Normal collision monitor with velocity polygon
+### Step 1: Normal collision monitor with velocity polygon
 
 ### Step 2: Steering validation
-If speed goes through zero (so sign(target speed) <> sign (current speed)) :
 
-* if abs(current speed) > Low threshold → keep steering angle (we must anyway just slow down asap)
+If speed goes through zero (so sign(target speed) <> sign(current speed)):
+
+* if abs(current speed) > low threshold → keep steering angle (we must anyway just slow down asap)
 * if abs(current speed) < low threshold → allow steering
 
 else:
 
-1. check if both abs(target) and abs(current speed) are < lower threshold. If yes → done
+1. check if both abs(target) and abs(current speed) are < low threshold. If yes → done
 2. check if target angle is in same bucket as current angle. If yes →
-  1. if yes → if abs(target speed) > abs(current speed), also check next faster bucket, if in collision, limit speed to current bucket → then done
-  2. if no → determine the direction of steering and the subsequent bucket from current angle
-3. in new bucket, determine max speed / valid bucket
-  1. start at fastest possible bucket (bucket for max (current speed, target speed)). If that is in collision, go down until the slowest one is found. that one we call “valid” bucket. If all buckets are in collision, use the slowest one with same speed sign in target direction (that is allowed even if in collision)
+   1. if the result velocity falls into the some faster field (same bucket), check the subsequent field for collision. Only the one-step faster field needs to be checked, even if target speed  is in a much faster field. if in collision, limit speed to current field → then done
+   2. if target angle is in a different bucket → determine the direction of steering and find the neighbouring bucket from current angle in that direction. Only one bucket step at a time, even if the target angle is several buckets away.
+3. in the neighbouring bucket, determine max speed / valid field
+   1. start at fastest possible field (field for max(current speed, target speed)). If that is in collision, go down until a collision-free one is found. That one we call “valid” field. If all fields are in collision, use the slowest one with same speed sign in target direction (that is allowed even if in collision)
 4. now adapt speed and steering angle
-  1. limit target speed to max speed of valid bucket
-  2. if current speed is larger than max valid speed: limit steering angle to boundary of current bucket
-
-
+   1. limit target speed to max speed of valid field
+   2. if current speed is larger than max valid speed: limit steering angle to boundary of current bucket
 
 → done
 
-After some iterations, the current speed will be in valid bucket → AMR will  be allowed to steer, as in 4b, the current speed will not be above max valid speedrrent speed will be in valid bucket → AMR will  be allowed to steer, as it will fall into case 3b
+After some iterations, the current speed will be in the valid field → AMR will be allowed to steer, as in 4b, the current speed will not be above max valid speed

--- a/nav2_collision_monitor/README.md
+++ b/nav2_collision_monitor/README.md
@@ -136,12 +136,13 @@ else:
   1. if yes → if abs(target speed) > abs(current speed), also check next faster bucket, if in collision, limit speed to current bucket → then done
   2. if no → determine the direction of steering and the subsequent bucket from current angle
 3. in new bucket, determine max speed / valid bucket
-  1. start at fastest possible bucket (bucket for max (current speed, target speed)). If that is in collision, go down until the slowest one is found. that one we call “valid” bucket
-  2. if the fastest possible bucket is not in collision → done
-4. now the AMR must decelerate to enter the valid bucket. Thus
-  1. limit steering angle at the boundary of current bucket
-  2. limit speed to max speed of valid bucket
+  1. start at fastest possible bucket (bucket for max (current speed, target speed)). If that is in collision, go down until the slowest one is found. that one we call “valid” bucket. If all buckets are in collision, use the slowest one with same speed sign in target direction (that is allowed even if in collision)
+4. now adapt speed and steering angle
+  1. limit target speed to max speed of valid bucket
+  2. if current speed is larger than max valid speed: limit steering angle to boundary of current bucket
+
+
 
 → done
 
-After some iterations, the current speed will be in valid bucket → AMR will  be allowed to steer, as it will fall into case 3b
+After some iterations, the current speed will be in valid bucket → AMR will  be allowed to steer, as in 4b, the current speed will not be above max valid speedrrent speed will be in valid bucket → AMR will  be allowed to steer, as it will fall into case 3b

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -250,6 +250,8 @@ protected:
   rclcpp::Time stop_stamp_;
   /// @brief Timeout after which 0-velocity ceases to be published
   rclcpp::Duration stop_pub_timeout_;
+  /// @brief Whether steering validation is enabled
+  bool enable_steering_validation_;
   /// @brief Active polygons publisher
   rclcpp::Publisher<nav2_msgs::msg::ActiveVelocityPolygons>::SharedPtr active_polygons_pub_;
 };  // class CollisionMonitor

--- a/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
@@ -15,8 +15,10 @@
 #ifndef NAV2_COLLISION_MONITOR__VELOCITY_POLYGON_HPP_
 #define NAV2_COLLISION_MONITOR__VELOCITY_POLYGON_HPP_
 
+#include <algorithm>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "geometry_msgs/msg/polygon_stamped.hpp"
@@ -74,6 +76,21 @@ public:
    */
   void updatePolygon(const Velocity & cmd_vel_in) override;
 
+  /**
+   * @brief Validates steering to prevent triggering lidar e-stop zones.
+   * Implements Step 2 of the lidar e-stop prevention algorithm.
+   * @param cmd_vel_in Desired robot velocity (target)
+   * @param odom_vel Current robot velocity from odometry
+   * @param collision_points_map Map of source name to collision points
+   * @param robot_action Output robot action to modify if steering is restricted
+   * @return True if velocity was modified by steering validation
+   */
+  bool validateSteering(
+    const Velocity & cmd_vel_in,
+    const Velocity & odom_vel,
+    const std::unordered_map<std::string, std::vector<Point>> & collision_points_map,
+    Action & robot_action);
+
 protected:
   /**
     * @brief Custom struct to store the parameters of the sub-polygon
@@ -119,6 +136,64 @@ protected:
    */
   bool isInRange(const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon_param);
 
+  /**
+   * @brief Convert baselink speed to steering wheel speed
+   * @param baselink_speed Baselink linear speed
+   * @param steering_angle Steering angle in radians
+   * @return Steering wheel speed
+   */
+  double baselinkToSteeringSpeed(double baselink_speed, double steering_angle) const;
+
+  /**
+   * @brief Convert steering wheel speed to baselink speed
+   * @param steering_speed Steering wheel speed
+   * @param steering_angle Steering angle in radians
+   * @return Baselink speed
+   */
+  double steeringToBaselinkSpeed(double steering_speed, double steering_angle) const;
+
+  /**
+   * @brief Convert steering angle back to angular velocity (twist.angular.z)
+   * @param baselink_speed Baselink linear speed
+   * @param steering_angle Steering angle in radians
+   * @return Angular velocity
+   */
+  double steeringAngleToTw(double baselink_speed, double steering_angle) const;
+
+  /**
+   * @brief Find the sub-polygon bucket matching a given steering wheel speed and steering angle
+   * @param steering_wheel_speed Speed in steering wheel frame
+   * @param steering_angle Steering angle in radians
+   * @return Pointer to matching sub-polygon, or nullptr if none found
+   */
+  const SubPolygonParameter * findBucket(
+    double steering_wheel_speed, double steering_angle) const;
+
+  /**
+   * @brief Find all sub-polygons matching a given steering angle, sorted by linear_min ascending
+   * @param steering_angle Steering angle in radians
+   * @return Vector of pointers to matching sub-polygons, sorted slowest first
+   */
+  std::vector<const SubPolygonParameter *> findBucketsForAngle(double steering_angle) const;
+
+  /**
+   * @brief Check if a point is inside a given polygon (arbitrary vertices)
+   * @param point Point to check
+   * @param vertices Polygon vertices
+   * @return True if point is inside polygon
+   */
+  static bool isPointInsidePoly(const Point & point, const std::vector<Point> & vertices);
+
+  /**
+   * @brief Get number of collision points inside a specific sub-polygon
+   * @param sub_polygon Sub-polygon to check against
+   * @param collision_points_map Map of source name to collision points
+   * @return Number of collision points inside the sub-polygon
+   */
+  int getPointsInsideSubPolygon(
+    const SubPolygonParameter & sub_polygon,
+    const std::unordered_map<std::string, std::vector<Point>> & collision_points_map) const;
+
   // Clock
   rclcpp::Clock::SharedPtr clock_;
   // Current subpolygon name
@@ -130,6 +205,8 @@ protected:
   double current_steering_angle_;
   /// @brief Distance between front and rear axes
   double wheelbase_;
+  /// @brief Speed below which steering is freely allowed
+  double low_speed_threshold_;
   /// @brief Vector to store the parameters of the sub-polygon
   std::vector<SubPolygonParameter> sub_polygons_;
 };  // class VelocityPolygon

--- a/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
@@ -137,12 +137,19 @@ protected:
   bool isInRange(const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon_param);
 
   /**
+   * @brief Compute steering angle from linear and angular velocity
+   * @param vel Velocity containing linear.x and angular.z
+   * @return Steering angle in radians
+   */
+  double computeSteeringAngle(const Velocity & vel) const;
+
+  /**
    * @brief Convert baselink speed to steering wheel speed
-   * @param baselink_speed Baselink linear speed
-   * @param steering_angle Steering angle in radians
+   * @param linear_vel Baselink linear velocity (twist.linear.x)
+   * @param angular_vel Baselink angular velocity (twist.angular.z)
    * @return Steering wheel speed
    */
-  double baselinkToSteeringSpeed(double baselink_speed, double steering_angle) const;
+  double baselinkToSteeringSpeed(double linear_vel, double angular_vel) const;
 
   /**
    * @brief Convert steering wheel speed to baselink speed
@@ -161,20 +168,23 @@ protected:
   double steeringAngleToTw(double baselink_speed, double steering_angle) const;
 
   /**
-   * @brief Find the sub-polygon bucket matching a given steering wheel speed and steering angle
+   * @brief Find the field (sub-polygon) matching a given steering wheel speed and steering angle
    * @param steering_wheel_speed Speed in steering wheel frame
    * @param steering_angle Steering angle in radians
    * @return Pointer to matching sub-polygon, or nullptr if none found
    */
-  const SubPolygonParameter * findBucket(
+  const SubPolygonParameter * findField(
     double steering_wheel_speed, double steering_angle) const;
 
   /**
-   * @brief Find all sub-polygons matching a given steering angle, sorted by linear_min ascending
+   * @brief Find all fields (sub-polygons) matching a given steering angle and direction
    * @param steering_angle Steering angle in radians
-   * @return Vector of pointers to matching sub-polygons, sorted slowest first
+   * @param forward If true, return only forward fields (linear_max >= 0);
+   *                if false, return only backward fields (linear_min <= 0)
+   * @return Vector of pointers to matching sub-polygons, sorted slowest (closest to zero) first
    */
-  std::vector<const SubPolygonParameter *> findBucketsForAngle(double steering_angle) const;
+  std::vector<const SubPolygonParameter *> findFieldsForAngle(
+    double steering_angle, bool forward) const;
 
   /**
    * @brief Check if a point is inside a given polygon (arbitrary vertices)

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -545,6 +545,20 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
     }
   }
 
+  // Step 2: Steering validation
+  for (auto polygon : polygons_) {
+    auto vel_polygon = std::dynamic_pointer_cast<VelocityPolygon>(polygon);
+    if (!vel_polygon || !polygon->getEnabled()) {
+      continue;
+    }
+    Velocity odom_vel{last_odom_msg_.linear.x, last_odom_msg_.linear.y, last_odom_msg_.angular.z};
+    if (vel_polygon->validateSteering(
+        cmd_vel_in, odom_vel, sources_collision_points_map, robot_action))
+    {
+      action_polygon = polygon;
+    }
+  }
+
   if (robot_action.polygon_name != robot_action_prev_.polygon_name) {
     // Report changed robot behavior
     notifyActionState(robot_action, action_polygon);

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -292,6 +292,10 @@ bool CollisionMonitor::getParameters(
   stop_pub_timeout_ =
     rclcpp::Duration::from_seconds(get_parameter("stop_pub_timeout").as_double());
 
+  nav2_util::declare_parameter_if_not_declared(
+    node, "enable_steering_validation", rclcpp::ParameterValue(true));
+  enable_steering_validation_ = get_parameter("enable_steering_validation").as_bool();
+
   if (
     !configureSources(
       base_frame_id, odom_frame_id, transform_tolerance, source_timeout, base_shift_correction))
@@ -546,16 +550,18 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
   }
 
   // Step 2: Steering validation
-  for (auto polygon : polygons_) {
-    auto vel_polygon = std::dynamic_pointer_cast<VelocityPolygon>(polygon);
-    if (!vel_polygon || !polygon->getEnabled()) {
-      continue;
-    }
-    Velocity odom_vel{last_odom_msg_.linear.x, last_odom_msg_.linear.y, last_odom_msg_.angular.z};
-    if (vel_polygon->validateSteering(
-        cmd_vel_in, odom_vel, sources_collision_points_map, robot_action))
-    {
-      action_polygon = polygon;
+  if (enable_steering_validation_) {
+    for (auto polygon : polygons_) {
+      auto vel_polygon = std::dynamic_pointer_cast<VelocityPolygon>(polygon);
+      if (!vel_polygon || !polygon->getEnabled()) {
+        continue;
+      }
+      Velocity odom_vel{last_odom_msg_.linear.x, last_odom_msg_.linear.y, last_odom_msg_.angular.z};
+      if (vel_polygon->validateSteering(
+          cmd_vel_in, odom_vel, sources_collision_points_map, robot_action))
+      {
+        action_polygon = polygon;
+      }
     }
   }
 

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -495,6 +495,15 @@ bool VelocityPolygon::validateSteering(
   const double target_steering_angle = computeSteeringAngle(cmd_vel_in);
   const double current_sa = computeSteeringAngle(odom_vel);
 
+  RCLCPP_INFO(
+    logger_,
+    "[%s] validateSteering: target_speed=%.3f, current_speed=%.3f, "
+    "target_sa=%.3f, current_sa=%.3f, cmd_vel_in=(%.3f, %.3f, %.3f), odom_vel=(%.3f, %.3f, %.3f)",
+    polygon_name_.c_str(), target_speed, current_speed,
+    target_steering_angle, current_sa,
+    cmd_vel_in.x, cmd_vel_in.y, cmd_vel_in.tw,
+    odom_vel.x, odom_vel.y, odom_vel.tw);
+
   bool modified = false;
   Velocity result_vel = robot_action.req_vel;
 
@@ -507,6 +516,11 @@ bool VelocityPolygon::validateSteering(
       // Must decelerate first — clamp tw to maintain current steering angle
       result_vel.tw = steeringAngleToTw(result_vel.x, current_sa);
       modified = true;
+      RCLCPP_INFO(
+        logger_,
+        "[%s] validateSteering: direction reversal detected, clamping tw to maintain "
+        "current_sa=%.3f (current_speed=%.3f > threshold=%.3f)",
+        polygon_name_.c_str(), current_sa, current_speed, low_speed_threshold_);
     }
     // else: abs(current) < threshold → allow steering freely
     if (modified) {
@@ -530,10 +544,22 @@ bool VelocityPolygon::validateSteering(
 
   const SubPolygonParameter * current_field = findField(current_sw_speed, current_sa);
 
+  RCLCPP_INFO(
+    logger_,
+    "[%s] validateSteering: target_sw_speed=%.3f, current_sw_speed=%.3f, "
+    "current_field=%s",
+    polygon_name_.c_str(), target_sw_speed, current_sw_speed,
+    current_field ? current_field->sub_polygon_name_.c_str() : "null");
+
   // 2. Check if target angle is in same bucket (angle range) as current
   bool same_bucket = current_field != nullptr &&
     target_steering_angle >= current_field->steering_angle_min_ &&
     target_steering_angle <= current_field->steering_angle_max_;
+
+  RCLCPP_INFO(
+    logger_,
+    "[%s] validateSteering: same_bucket=%s",
+    polygon_name_.c_str(), same_bucket ? "true" : "false");
 
   if (same_bucket) {
     // If result velocity falls into some faster field (same bucket), check the
@@ -555,6 +581,12 @@ bool VelocityPolygon::validateSteering(
               current_field->linear_max_ : current_field->linear_min_;
             double max_baselink = steeringToBaselinkSpeed(limit_sw, current_sa);
             if (std::abs(result_vel.x) > std::abs(max_baselink)) {
+              RCLCPP_INFO(
+                logger_,
+                "[%s] validateSteering: same_bucket speed limit — next field '%s' in collision, "
+                "limiting vel.x from %.3f to %.3f (sw_limit=%.3f)",
+                polygon_name_.c_str(), next_field->sub_polygon_name_.c_str(),
+                result_vel.x, max_baselink, limit_sw);
               result_vel.x = max_baselink;
               result_vel.tw = steeringAngleToTw(result_vel.x, target_steering_angle);
               modified = true;
@@ -574,6 +606,11 @@ bool VelocityPolygon::validateSteering(
   }
 
   // 3. Different bucket — find neighbouring bucket (one step in steering direction)
+  RCLCPP_INFO(
+    logger_,
+    "[%s] validateSteering: different bucket — target_sa=%.3f outside current field [%.3f, %.3f]",
+    polygon_name_.c_str(), target_steering_angle,
+    current_field->steering_angle_min_, current_field->steering_angle_max_);
   double neighbour_angle;
   if (target_steering_angle > current_sa) {
     neighbour_angle = current_field->steering_angle_max_;
@@ -629,6 +666,16 @@ bool VelocityPolygon::validateSteering(
     // All fields in collision — use the slowest field in the target direction
     // (allowed even if in collision)
     valid_field = neighbour_fields[0];  // sorted ascending, index 0 is slowest
+    RCLCPP_INFO(
+      logger_,
+      "[%s] validateSteering: all neighbour fields in collision, "
+      "falling back to slowest field '%s'",
+      polygon_name_.c_str(), valid_field->sub_polygon_name_.c_str());
+  } else {
+    RCLCPP_INFO(
+      logger_,
+      "[%s] validateSteering: valid neighbour field found: '%s'",
+      polygon_name_.c_str(), valid_field->sub_polygon_name_.c_str());
   }
 
   // 4. Adapt speed and steering angle
@@ -639,6 +686,12 @@ bool VelocityPolygon::validateSteering(
   double valid_max_baselink = steeringToBaselinkSpeed(
     valid_limit_sw, neighbour_angle);
   if (std::abs(result_vel.x) > std::abs(valid_max_baselink)) {
+    RCLCPP_INFO(
+      logger_,
+      "[%s] validateSteering: limiting speed from %.3f to %.3f "
+      "(valid_limit_sw=%.3f, neighbour_angle=%.3f)",
+      polygon_name_.c_str(), result_vel.x, valid_max_baselink,
+      valid_limit_sw, neighbour_angle);
     result_vel.x = valid_max_baselink;
   }
 
@@ -652,8 +705,18 @@ bool VelocityPolygon::validateSteering(
     } else {
       limited_sa = current_field->steering_angle_min_;
     }
+    RCLCPP_INFO(
+      logger_,
+      "[%s] validateSteering: limiting steering angle to %.3f "
+      "(current_speed=%.3f > valid_max=%.3f)",
+      polygon_name_.c_str(), limited_sa, current_baselink_abs, valid_max_baselink_abs);
     result_vel.tw = steeringAngleToTw(result_vel.x, limited_sa);
   }
+
+  RCLCPP_INFO(
+    logger_,
+    "[%s] validateSteering: final result_vel=(%.3f, %.3f, %.3f)",
+    polygon_name_.c_str(), result_vel.x, result_vel.y, result_vel.tw);
 
   robot_action.req_vel = result_vel;
   robot_action.polygon_name = polygon_name_;

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -297,21 +297,10 @@ void VelocityPolygon::updatePolygon(const Velocity & cmd_vel_in)
 
 bool VelocityPolygon::isInRange(const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon) {
   if (sub_polygon.use_steering_angle_) {
-    // Compute steering angle first (needed for speed conversion)
-    if (std::abs(cmd_vel_in.x) < 1e-6) {
-      current_steering_angle_ = (std::abs(cmd_vel_in.tw) < 1e-6) ?
-                               0.0 :
-                               (cmd_vel_in.tw > 0 ? M_PI/2 : -M_PI/2);
-    } else {
-      double angular_vel = cmd_vel_in.tw;
-      if (cmd_vel_in.x < 0) {
-        angular_vel = -angular_vel;
-      }
-      current_steering_angle_ = std::atan2(wheelbase_ * angular_vel, std::abs(cmd_vel_in.x));
-    }
+    current_steering_angle_ = computeSteeringAngle(cmd_vel_in);
 
-    // Convert baselink speed to steering wheel speed: v_steering = v_baselink / cos(steering_angle)
-    double steering_wheel_speed = baselinkToSteeringSpeed(cmd_vel_in.x, current_steering_angle_);
+    // Convert baselink speed to steering wheel speed
+    double steering_wheel_speed = baselinkToSteeringSpeed(cmd_vel_in.x, cmd_vel_in.tw);
 
     RCLCPP_DEBUG(
       logger_,
@@ -368,15 +357,26 @@ bool VelocityPolygon::isInRange(const Velocity & cmd_vel_in, const SubPolygonPar
   return in_range;
 }
 
-double VelocityPolygon::baselinkToSteeringSpeed(
-  double baselink_speed, double steering_angle) const
+double VelocityPolygon::computeSteeringAngle(const Velocity & vel) const
 {
-  double cos_sa = std::cos(steering_angle);
-  if (std::abs(cos_sa) < 1e-6) {
-    // Near 90 degree steering — return a very large speed to signal out-of-range
-    return (baselink_speed >= 0.0 ? 1e6 : -1e6);
+  if (std::abs(vel.x) < 1e-6) {
+    return (std::abs(vel.tw) < 1e-6) ? 0.0 : (vel.tw > 0 ? M_PI / 2 : -M_PI / 2);
   }
-  return baselink_speed / cos_sa;
+  double angular_vel = vel.tw;
+  if (vel.x < 0) {
+    angular_vel = -angular_vel;
+  }
+  return std::atan2(wheelbase_ * angular_vel, std::abs(vel.x));
+}
+
+double VelocityPolygon::baselinkToSteeringSpeed(
+  double linear_vel, double angular_vel) const
+{
+  double magnitude = std::hypot(linear_vel, wheelbase_ * angular_vel);
+  if (linear_vel < 0.0) {
+    return -magnitude;
+  }
+  return magnitude;
 }
 
 double VelocityPolygon::steeringToBaselinkSpeed(
@@ -396,7 +396,7 @@ double VelocityPolygon::steeringAngleToTw(
   return tw;
 }
 
-const VelocityPolygon::SubPolygonParameter * VelocityPolygon::findBucket(
+const VelocityPolygon::SubPolygonParameter * VelocityPolygon::findField(
   double steering_wheel_speed, double steering_angle) const
 {
   for (const auto & sp : sub_polygons_) {
@@ -413,7 +413,7 @@ const VelocityPolygon::SubPolygonParameter * VelocityPolygon::findBucket(
 }
 
 std::vector<const VelocityPolygon::SubPolygonParameter *>
-VelocityPolygon::findBucketsForAngle(double steering_angle) const
+VelocityPolygon::findFieldsForAngle(double steering_angle, bool forward) const
 {
   std::vector<const SubPolygonParameter *> result;
   for (const auto & sp : sub_polygons_) {
@@ -421,13 +421,15 @@ VelocityPolygon::findBucketsForAngle(double steering_angle) const
       continue;
     }
     if (steering_angle >= sp.steering_angle_min_ && steering_angle <= sp.steering_angle_max_) {
-      result.push_back(&sp);
+      if (forward ? (sp.linear_max_ >= 0) : (sp.linear_min_ <= 0)) {
+        result.push_back(&sp);
+      }
     }
   }
-  // Sort ascending by linear_min_ (slowest first)
+  // Sort by speed magnitude ascending (slowest/closest to zero first)
   std::sort(result.begin(), result.end(),
     [](const SubPolygonParameter * a, const SubPolygonParameter * b) {
-      return a->linear_min_ < b->linear_min_;
+      return std::abs(a->linear_min_) < std::abs(b->linear_min_);
     });
   return result;
 }
@@ -490,31 +492,8 @@ bool VelocityPolygon::validateSteering(
   const double target_speed = cmd_vel_in.x;
   const double current_speed = odom_vel.x;
 
-  // Compute target steering angle
-  double target_steering_angle;
-  if (std::abs(cmd_vel_in.x) < 1e-6) {
-    target_steering_angle = (std::abs(cmd_vel_in.tw) < 1e-6) ?
-      0.0 : (cmd_vel_in.tw > 0 ? M_PI / 2 : -M_PI / 2);
-  } else {
-    double angular_vel = cmd_vel_in.tw;
-    if (cmd_vel_in.x < 0) {
-      angular_vel = -angular_vel;
-    }
-    target_steering_angle = std::atan2(wheelbase_ * angular_vel, std::abs(cmd_vel_in.x));
-  }
-
-  // Compute current steering angle from odometry
-  double current_sa;
-  if (std::abs(odom_vel.x) < 1e-6) {
-    current_sa = (std::abs(odom_vel.tw) < 1e-6) ?
-      0.0 : (odom_vel.tw > 0 ? M_PI / 2 : -M_PI / 2);
-  } else {
-    double angular_vel = odom_vel.tw;
-    if (odom_vel.x < 0) {
-      angular_vel = -angular_vel;
-    }
-    current_sa = std::atan2(wheelbase_ * angular_vel, std::abs(odom_vel.x));
-  }
+  const double target_steering_angle = computeSteeringAngle(cmd_vel_in);
+  const double current_sa = computeSteeringAngle(odom_vel);
 
   bool modified = false;
   Velocity result_vel = robot_action.req_vel;
@@ -546,29 +525,37 @@ bool VelocityPolygon::validateSteering(
     return false;
   }
 
-  double target_sw_speed = baselinkToSteeringSpeed(target_speed, target_steering_angle);
-  double current_sw_speed = baselinkToSteeringSpeed(current_speed, current_sa);
+  double target_sw_speed = baselinkToSteeringSpeed(cmd_vel_in.x, cmd_vel_in.tw);
+  double current_sw_speed = baselinkToSteeringSpeed(odom_vel.x, odom_vel.tw);
 
-  const SubPolygonParameter * current_bucket = findBucket(current_sw_speed, current_sa);
-  const SubPolygonParameter * target_bucket = findBucket(target_sw_speed, target_steering_angle);
+  const SubPolygonParameter * current_field = findField(current_sw_speed, current_sa);
 
-  // 2. Target angle in same bucket as current angle
-  if (target_bucket != nullptr && current_bucket != nullptr &&
-    target_bucket == current_bucket)
-  {
-    // Same bucket
-    if (std::abs(target_sw_speed) > std::abs(current_sw_speed)) {
-      // Accelerating — check next faster bucket at target angle for collision
-      auto buckets_at_angle = findBucketsForAngle(target_steering_angle);
-      for (size_t i = 0; i < buckets_at_angle.size(); i++) {
-        if (buckets_at_angle[i] == current_bucket && i + 1 < buckets_at_angle.size()) {
-          const SubPolygonParameter * next_bucket = buckets_at_angle[i + 1];
-          if (getPointsInsideSubPolygon(*next_bucket, collision_points_map) >= min_points_) {
-            // Collision in next bucket — limit speed to current bucket's linear_max
-            double max_baselink = steeringToBaselinkSpeed(
-              current_bucket->linear_max_, current_sa);
+  // 2. Check if target angle is in same bucket (angle range) as current
+  bool same_bucket = current_field != nullptr &&
+    target_steering_angle >= current_field->steering_angle_min_ &&
+    target_steering_angle <= current_field->steering_angle_max_;
+
+  if (same_bucket) {
+    // If result velocity falls into some faster field (same bucket), check the
+    // one-step-faster field for collision. If in collision, limit to current field.
+    double result_sw_speed = baselinkToSteeringSpeed(result_vel.x, result_vel.tw);
+    const SubPolygonParameter * result_field = findField(result_sw_speed, target_steering_angle);
+    if (result_field != nullptr && result_field != current_field &&
+      std::abs(result_sw_speed) > std::abs(current_sw_speed))
+    {
+      bool forward = current_sw_speed >= 0;
+      auto fields_at_angle = findFieldsForAngle(target_steering_angle, forward);
+      for (size_t i = 0; i < fields_at_angle.size(); i++) {
+        if (fields_at_angle[i] == current_field && i + 1 < fields_at_angle.size()) {
+          const SubPolygonParameter * next_field = fields_at_angle[i + 1];
+          if (getPointsInsideSubPolygon(*next_field, collision_points_map) >= min_points_) {
+            // Forward: limit to linear_max (upper bound)
+            // Backward: limit to linear_min (lower bound, more negative = faster)
+            double limit_sw = (current_sw_speed >= 0) ?
+              current_field->linear_max_ : current_field->linear_min_;
+            double max_baselink = steeringToBaselinkSpeed(limit_sw, current_sa);
             if (std::abs(result_vel.x) > std::abs(max_baselink)) {
-              result_vel.x = (result_vel.x >= 0) ? std::abs(max_baselink) : -std::abs(max_baselink);
+              result_vel.x = max_baselink;
               result_vel.tw = steeringAngleToTw(result_vel.x, target_steering_angle);
               modified = true;
             }
@@ -577,7 +564,7 @@ bool VelocityPolygon::validateSteering(
         }
       }
     }
-    // Otherwise (decelerating or same speed) → done
+    // Same bucket → done
     if (modified) {
       robot_action.req_vel = result_vel;
       robot_action.polygon_name = polygon_name_;
@@ -586,71 +573,84 @@ bool VelocityPolygon::validateSteering(
     return modified;
   }
 
-  // 3. Target angle in different bucket
-  // Find all buckets at target angle
-  auto target_buckets = findBucketsForAngle(target_steering_angle);
-  if (target_buckets.empty()) {
+  // 3. Different bucket — find neighbouring bucket (one step in steering direction)
+  double neighbour_angle;
+  if (target_steering_angle > current_sa) {
+    neighbour_angle = current_field->steering_angle_max_;
+  } else {
+    neighbour_angle = current_field->steering_angle_min_;
+  }
+  // Step just past the boundary to land in the neighbouring bucket
+  constexpr double kAngleEps = 0.01;
+  double lookup_angle = (target_steering_angle > current_sa) ?
+    neighbour_angle + kAngleEps : neighbour_angle - kAngleEps;
+
+  bool forward = target_sw_speed >= 0;
+  auto neighbour_fields = findFieldsForAngle(lookup_angle, forward);
+  if (neighbour_fields.empty()) {
     return false;
   }
 
-  // Find the fastest bucket that covers max(|current|, |target|) speed
+  // Find the fastest field that covers max(|current|, |target|) speed
   double max_sw_speed = std::max(std::abs(current_sw_speed), std::abs(target_sw_speed));
 
-  // Find the valid bucket: start from fastest covering bucket, walk down
-  const SubPolygonParameter * valid_bucket = nullptr;
-  int start_idx = static_cast<int>(target_buckets.size()) - 1;
+  // Find the valid field: start from fastest covering field, walk down
+  const SubPolygonParameter * valid_field = nullptr;
+  int start_idx = static_cast<int>(neighbour_fields.size()) - 1;
 
-  // Find the starting bucket (fastest that covers max_sw_speed)
+  // Find the starting field (fastest that covers max_sw_speed)
   for (int i = start_idx; i >= 0; i--) {
-    if (max_sw_speed >= target_buckets[i]->linear_min_ &&
-      max_sw_speed <= target_buckets[i]->linear_max_)
+    if (max_sw_speed >= std::abs(neighbour_fields[i]->linear_min_) &&
+      max_sw_speed <= std::abs(neighbour_fields[i]->linear_max_))
     {
       start_idx = i;
       break;
     }
-    // If max_sw_speed is beyond all buckets, start from the fastest
+    // If max_sw_speed is beyond all fields, start from the fastest
     if (i == 0) {
-      start_idx = static_cast<int>(target_buckets.size()) - 1;
+      start_idx = static_cast<int>(neighbour_fields.size()) - 1;
     }
   }
 
-  // Check if fastest bucket is collision-free → done
-  if (getPointsInsideSubPolygon(*target_buckets[start_idx], collision_points_map) < min_points_) {
+  // Check if fastest field is collision-free → done
+  if (getPointsInsideSubPolygon(*neighbour_fields[start_idx], collision_points_map) < min_points_) {
     return false;
   }
 
-  // Walk down speed buckets until a collision-free one is found
+  // Walk down speed fields until a collision-free one is found
   for (int i = start_idx; i >= 0; i--) {
-    if (getPointsInsideSubPolygon(*target_buckets[i], collision_points_map) < min_points_) {
-      valid_bucket = target_buckets[i];
+    if (getPointsInsideSubPolygon(*neighbour_fields[i], collision_points_map) < min_points_) {
+      valid_field = neighbour_fields[i];
       break;
     }
   }
 
-  if (valid_bucket == nullptr) {
-    // All buckets in collision — use the slowest bucket in the target direction
+  if (valid_field == nullptr) {
+    // All fields in collision — use the slowest field in the target direction
     // (allowed even if in collision)
-    valid_bucket = target_buckets[0];  // sorted ascending, index 0 is slowest
+    valid_field = neighbour_fields[0];  // sorted ascending, index 0 is slowest
   }
 
   // 4. Adapt speed and steering angle
-  // 4a. Limit target speed to valid bucket's linear_max (converted to baselink)
+  // 4a. Limit target speed to valid field's speed boundary (converted to baselink)
+  // Forward: limit to linear_max; Backward: limit to linear_min
+  double valid_limit_sw = (target_sw_speed >= 0) ?
+    valid_field->linear_max_ : valid_field->linear_min_;
   double valid_max_baselink = steeringToBaselinkSpeed(
-    valid_bucket->linear_max_, target_steering_angle);
+    valid_limit_sw, neighbour_angle);
   if (std::abs(result_vel.x) > std::abs(valid_max_baselink)) {
-    result_vel.x = (result_vel.x >= 0) ? std::abs(valid_max_baselink) :
-      -std::abs(valid_max_baselink);
+    result_vel.x = valid_max_baselink;
   }
 
   // 4b. Only limit steering angle if current speed is larger than max valid speed
   double current_baselink_abs = std::abs(current_speed);
   double valid_max_baselink_abs = std::abs(valid_max_baselink);
-  if (current_baselink_abs > valid_max_baselink_abs && current_bucket != nullptr) {
+  if (current_baselink_abs > valid_max_baselink_abs && current_field != nullptr) {
     double limited_sa;
     if (target_steering_angle > current_sa) {
-      limited_sa = current_bucket->steering_angle_max_;
+      limited_sa = current_field->steering_angle_max_;
     } else {
-      limited_sa = current_bucket->steering_angle_min_;
+      limited_sa = current_field->steering_angle_min_;
     }
     result_vel.tw = steeringAngleToTw(result_vel.x, limited_sa);
   }

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -14,6 +14,9 @@
 
 #include "nav2_collision_monitor/velocity_polygon.hpp"
 
+#include <algorithm>
+#include <cmath>
+
 #include "nav2_util/node_utils.hpp"
 
 namespace nav2_collision_monitor
@@ -63,6 +66,11 @@ bool VelocityPolygon::getParameters(
     nav2_util::declare_parameter_if_not_declared(
       node, polygon_name_ + ".wheelbase", rclcpp::ParameterValue(1.0));
     wheelbase_ = node->get_parameter(polygon_name_ + ".wheelbase").as_double();
+
+    nav2_util::declare_parameter_if_not_declared(
+      node, polygon_name_ + ".low_speed_threshold", rclcpp::ParameterValue(0.1));
+    low_speed_threshold_ = node->get_parameter(
+      polygon_name_ + ".low_speed_threshold").as_double();
 
     for (std::string velocity_polygon_name : velocity_polygons) {
       // polygon points parameter
@@ -263,7 +271,13 @@ void VelocityPolygon::updatePolygon(const Velocity & cmd_vel_in)
       }
 
       slowdown_ratio_ = sub_polygon.slowdown_ratio_;
-      linear_limit_ = sub_polygon.linear_limit_;
+      if (sub_polygon.use_steering_angle_) {
+        // Convert linear_limit from steering wheel speed to baselink speed
+        linear_limit_ = steeringToBaselinkSpeed(
+          sub_polygon.linear_limit_, current_steering_angle_);
+      } else {
+        linear_limit_ = sub_polygon.linear_limit_;
+      }
       angular_limit_ = sub_polygon.angular_limit_;
       time_before_collision_ = sub_polygon.time_before_collision_;
 
@@ -282,14 +296,8 @@ void VelocityPolygon::updatePolygon(const Velocity & cmd_vel_in)
 }
 
 bool VelocityPolygon::isInRange(const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon) {
-  bool in_range = cmd_vel_in.x <= sub_polygon.linear_max_ &&
-                  cmd_vel_in.x >= sub_polygon.linear_min_;
-
-  if (!in_range) {
-    return false;
-  }
-
   if (sub_polygon.use_steering_angle_) {
+    // Compute steering angle first (needed for speed conversion)
     if (std::abs(cmd_vel_in.x) < 1e-6) {
       current_steering_angle_ = (std::abs(cmd_vel_in.tw) < 1e-6) ?
                                0.0 :
@@ -299,26 +307,49 @@ bool VelocityPolygon::isInRange(const Velocity & cmd_vel_in, const SubPolygonPar
       if (cmd_vel_in.x < 0) {
         angular_vel = -angular_vel;
       }
-
       current_steering_angle_ = std::atan2(wheelbase_ * angular_vel, std::abs(cmd_vel_in.x));
     }
 
+    // Convert baselink speed to steering wheel speed: v_steering = v_baselink / cos(steering_angle)
+    double steering_wheel_speed = baselinkToSteeringSpeed(cmd_vel_in.x, current_steering_angle_);
+
     RCLCPP_DEBUG(
       logger_,
-      "Calculated steering angle: %.2f (limits: %.2f to %.2f), linear_vel: %.2f, angular_vel: %.2f",
+      "Calculated steering angle: %.2f (limits: %.2f to %.2f), "
+      "baselink_vel: %.2f, steering_wheel_speed: %.2f, angular_vel: %.2f",
       current_steering_angle_,
       sub_polygon.steering_angle_min_,
       sub_polygon.steering_angle_max_,
       cmd_vel_in.x,
+      steering_wheel_speed,
       cmd_vel_in.tw
     );
 
+    // Check linear range using steering wheel speed
+    bool in_range = steering_wheel_speed <= sub_polygon.linear_max_ &&
+                    steering_wheel_speed >= sub_polygon.linear_min_;
+
+    if (!in_range) {
+      return false;
+    }
+
+    // Check steering angle range
     in_range &= current_steering_angle_ <= sub_polygon.steering_angle_max_ &&
                 current_steering_angle_ >= sub_polygon.steering_angle_min_;
-  } else {
-    in_range &= cmd_vel_in.tw <= sub_polygon.theta_max_ &&
-                cmd_vel_in.tw >= sub_polygon.theta_min_;
+
+    return in_range;
   }
+
+  // Non-steering-angle mode: use baselink speed directly
+  bool in_range = cmd_vel_in.x <= sub_polygon.linear_max_ &&
+                  cmd_vel_in.x >= sub_polygon.linear_min_;
+
+  if (!in_range) {
+    return false;
+  }
+
+  in_range &= cmd_vel_in.tw <= sub_polygon.theta_max_ &&
+              cmd_vel_in.tw >= sub_polygon.theta_min_;
 
   if (holonomic_) {
     // Additionally check if moving direction in angle range(start -> end) for holonomic case
@@ -335,6 +366,311 @@ bool VelocityPolygon::isInRange(const Velocity & cmd_vel_in, const SubPolygonPar
   }
 
   return in_range;
+}
+
+double VelocityPolygon::baselinkToSteeringSpeed(
+  double baselink_speed, double steering_angle) const
+{
+  double cos_sa = std::cos(steering_angle);
+  if (std::abs(cos_sa) < 1e-6) {
+    // Near 90 degree steering — return a very large speed to signal out-of-range
+    return (baselink_speed >= 0.0 ? 1e6 : -1e6);
+  }
+  return baselink_speed / cos_sa;
+}
+
+double VelocityPolygon::steeringToBaselinkSpeed(
+  double steering_speed, double steering_angle) const
+{
+  return steering_speed * std::cos(steering_angle);
+}
+
+double VelocityPolygon::steeringAngleToTw(
+  double baselink_speed, double steering_angle) const
+{
+  // tw = tan(angle) * |v| / wheelbase, sign-corrected for reverse
+  double tw = std::tan(steering_angle) * std::abs(baselink_speed) / wheelbase_;
+  if (baselink_speed < 0.0) {
+    tw = -tw;
+  }
+  return tw;
+}
+
+const VelocityPolygon::SubPolygonParameter * VelocityPolygon::findBucket(
+  double steering_wheel_speed, double steering_angle) const
+{
+  for (const auto & sp : sub_polygons_) {
+    if (!sp.use_steering_angle_) {
+      continue;
+    }
+    if (steering_wheel_speed >= sp.linear_min_ && steering_wheel_speed <= sp.linear_max_ &&
+      steering_angle >= sp.steering_angle_min_ && steering_angle <= sp.steering_angle_max_)
+    {
+      return &sp;
+    }
+  }
+  return nullptr;
+}
+
+std::vector<const VelocityPolygon::SubPolygonParameter *>
+VelocityPolygon::findBucketsForAngle(double steering_angle) const
+{
+  std::vector<const SubPolygonParameter *> result;
+  for (const auto & sp : sub_polygons_) {
+    if (!sp.use_steering_angle_) {
+      continue;
+    }
+    if (steering_angle >= sp.steering_angle_min_ && steering_angle <= sp.steering_angle_max_) {
+      result.push_back(&sp);
+    }
+  }
+  // Sort ascending by linear_min_ (slowest first)
+  std::sort(result.begin(), result.end(),
+    [](const SubPolygonParameter * a, const SubPolygonParameter * b) {
+      return a->linear_min_ < b->linear_min_;
+    });
+  return result;
+}
+
+bool VelocityPolygon::isPointInsidePoly(
+  const Point & point, const std::vector<Point> & vertices)
+{
+  // Ray-casting algorithm (same as Polygon::isPointInside but for arbitrary vertices)
+  const int poly_size = static_cast<int>(vertices.size());
+  int i, j;
+  bool res = false;
+
+  i = poly_size - 1;
+  for (j = 0; j < poly_size; j++) {
+    if ((point.y <= vertices[i].y) == (point.y > vertices[j].y)) {
+      const double x_inter = vertices[i].x +
+        (point.y - vertices[i].y) * (vertices[j].x - vertices[i].x) /
+        (vertices[j].y - vertices[i].y);
+      if (x_inter > point.x) {
+        res = !res;
+      }
+    }
+    i = j;
+  }
+  return res;
+}
+
+int VelocityPolygon::getPointsInsideSubPolygon(
+  const SubPolygonParameter & sub_polygon,
+  const std::unordered_map<std::string, std::vector<Point>> & collision_points_map) const
+{
+  int num = 0;
+  std::vector<std::string> polygon_sources_names = getSourcesNames();
+
+  for (const auto & source_name : polygon_sources_names) {
+    const auto & iter = collision_points_map.find(source_name);
+    if (iter != collision_points_map.end()) {
+      for (const auto & point : iter->second) {
+        if (isPointInsidePoly(point, sub_polygon.poly_)) {
+          num++;
+        }
+      }
+    }
+  }
+
+  return num;
+}
+
+bool VelocityPolygon::validateSteering(
+  const Velocity & cmd_vel_in,
+  const Velocity & odom_vel,
+  const std::unordered_map<std::string, std::vector<Point>> & collision_points_map,
+  Action & robot_action)
+{
+  // Only applies to steering-angle-based velocity polygons
+  if (sub_polygons_.empty() || !sub_polygons_[0].use_steering_angle_) {
+    return false;
+  }
+
+  const double target_speed = cmd_vel_in.x;
+  const double current_speed = odom_vel.x;
+
+  // Compute target steering angle
+  double target_steering_angle;
+  if (std::abs(cmd_vel_in.x) < 1e-6) {
+    target_steering_angle = (std::abs(cmd_vel_in.tw) < 1e-6) ?
+      0.0 : (cmd_vel_in.tw > 0 ? M_PI / 2 : -M_PI / 2);
+  } else {
+    double angular_vel = cmd_vel_in.tw;
+    if (cmd_vel_in.x < 0) {
+      angular_vel = -angular_vel;
+    }
+    target_steering_angle = std::atan2(wheelbase_ * angular_vel, std::abs(cmd_vel_in.x));
+  }
+
+  // Compute current steering angle from odometry
+  double current_sa;
+  if (std::abs(odom_vel.x) < 1e-6) {
+    current_sa = (std::abs(odom_vel.tw) < 1e-6) ?
+      0.0 : (odom_vel.tw > 0 ? M_PI / 2 : -M_PI / 2);
+  } else {
+    double angular_vel = odom_vel.tw;
+    if (odom_vel.x < 0) {
+      angular_vel = -angular_vel;
+    }
+    current_sa = std::atan2(wheelbase_ * angular_vel, std::abs(odom_vel.x));
+  }
+
+  bool modified = false;
+  Velocity result_vel = robot_action.req_vel;
+
+  // Check if speed crosses zero (direction reversal)
+  bool crosses_zero = (target_speed > 0 && current_speed < 0) ||
+    (target_speed < 0 && current_speed > 0);
+
+  if (crosses_zero) {
+    if (std::abs(current_speed) > low_speed_threshold_) {
+      // Must decelerate first — clamp tw to maintain current steering angle
+      result_vel.tw = steeringAngleToTw(result_vel.x, current_sa);
+      modified = true;
+    }
+    // else: abs(current) < threshold → allow steering freely
+    if (modified) {
+      robot_action.req_vel = result_vel;
+      robot_action.polygon_name = polygon_name_;
+      robot_action.action_type = LIMIT;
+    }
+    return modified;
+  }
+
+  // Speed does NOT cross zero
+  // 1. Both abs(target) and abs(current) below threshold → done
+  if (std::abs(target_speed) < low_speed_threshold_ &&
+    std::abs(current_speed) < low_speed_threshold_)
+  {
+    return false;
+  }
+
+  double target_sw_speed = baselinkToSteeringSpeed(target_speed, target_steering_angle);
+  double current_sw_speed = baselinkToSteeringSpeed(current_speed, current_sa);
+
+  const SubPolygonParameter * current_bucket = findBucket(current_sw_speed, current_sa);
+  const SubPolygonParameter * target_bucket = findBucket(target_sw_speed, target_steering_angle);
+
+  // 2. Target angle in same bucket as current angle
+  if (target_bucket != nullptr && current_bucket != nullptr &&
+    target_bucket == current_bucket)
+  {
+    // Same bucket
+    if (std::abs(target_sw_speed) > std::abs(current_sw_speed)) {
+      // Accelerating — check next faster bucket at target angle for collision
+      auto buckets_at_angle = findBucketsForAngle(target_steering_angle);
+      for (size_t i = 0; i < buckets_at_angle.size(); i++) {
+        if (buckets_at_angle[i] == current_bucket && i + 1 < buckets_at_angle.size()) {
+          const SubPolygonParameter * next_bucket = buckets_at_angle[i + 1];
+          if (getPointsInsideSubPolygon(*next_bucket, collision_points_map) >= min_points_) {
+            // Collision in next bucket — limit speed to current bucket's linear_max
+            double max_baselink = steeringToBaselinkSpeed(
+              current_bucket->linear_max_, current_sa);
+            if (std::abs(result_vel.x) > std::abs(max_baselink)) {
+              result_vel.x = (result_vel.x >= 0) ? std::abs(max_baselink) : -std::abs(max_baselink);
+              result_vel.tw = steeringAngleToTw(result_vel.x, target_steering_angle);
+              modified = true;
+            }
+          }
+          break;
+        }
+      }
+    }
+    // Otherwise (decelerating or same speed) → done
+    if (modified) {
+      robot_action.req_vel = result_vel;
+      robot_action.polygon_name = polygon_name_;
+      robot_action.action_type = LIMIT;
+    }
+    return modified;
+  }
+
+  // 3. Target angle in different bucket
+  // Find all buckets at target angle
+  auto target_buckets = findBucketsForAngle(target_steering_angle);
+  if (target_buckets.empty()) {
+    return false;
+  }
+
+  // Find the fastest bucket that covers max(|current|, |target|) speed
+  double max_sw_speed = std::max(std::abs(current_sw_speed), std::abs(target_sw_speed));
+
+  // Find the valid bucket: start from fastest covering bucket, walk down
+  const SubPolygonParameter * valid_bucket = nullptr;
+  int start_idx = static_cast<int>(target_buckets.size()) - 1;
+
+  // Find the starting bucket (fastest that covers max_sw_speed)
+  for (int i = start_idx; i >= 0; i--) {
+    if (max_sw_speed >= target_buckets[i]->linear_min_ &&
+      max_sw_speed <= target_buckets[i]->linear_max_)
+    {
+      start_idx = i;
+      break;
+    }
+    // If max_sw_speed is beyond all buckets, start from the fastest
+    if (i == 0) {
+      start_idx = static_cast<int>(target_buckets.size()) - 1;
+    }
+  }
+
+  // Check if fastest bucket is collision-free → done
+  if (getPointsInsideSubPolygon(*target_buckets[start_idx], collision_points_map) < min_points_) {
+    return false;
+  }
+
+  // Walk down speed buckets until a collision-free one is found
+  for (int i = start_idx; i >= 0; i--) {
+    if (getPointsInsideSubPolygon(*target_buckets[i], collision_points_map) < min_points_) {
+      valid_bucket = target_buckets[i];
+      break;
+    }
+  }
+
+  if (valid_bucket == nullptr) {
+    // No valid bucket exists → STOP
+    robot_action.req_vel.x = 0.0;
+    robot_action.req_vel.y = 0.0;
+    robot_action.req_vel.tw = 0.0;
+    robot_action.polygon_name = polygon_name_;
+    robot_action.action_type = STOP;
+    return true;
+  }
+
+  // 4. Decelerate to valid bucket
+  // Limit steering angle to boundary of current bucket (toward target direction)
+  if (current_bucket != nullptr) {
+    double limited_sa;
+    if (target_steering_angle > current_sa) {
+      limited_sa = current_bucket->steering_angle_max_;
+    } else {
+      limited_sa = current_bucket->steering_angle_min_;
+    }
+    result_vel.tw = steeringAngleToTw(result_vel.x, limited_sa);
+  }
+
+  // Limit speed to valid bucket's linear_max (converted to baselink)
+  double valid_max_baselink = steeringToBaselinkSpeed(
+    valid_bucket->linear_max_, target_steering_angle);
+  if (std::abs(result_vel.x) > std::abs(valid_max_baselink)) {
+    result_vel.x = (result_vel.x >= 0) ? std::abs(valid_max_baselink) :
+      -std::abs(valid_max_baselink);
+    // Recalculate tw for the new speed
+    if (current_bucket != nullptr) {
+      double limited_sa;
+      if (target_steering_angle > current_sa) {
+        limited_sa = current_bucket->steering_angle_max_;
+      } else {
+        limited_sa = current_bucket->steering_angle_min_;
+      }
+      result_vel.tw = steeringAngleToTw(result_vel.x, limited_sa);
+    }
+  }
+
+  robot_action.req_vel = result_vel;
+  robot_action.polygon_name = polygon_name_;
+  robot_action.action_type = LIMIT;
+  return true;
 }
 
 }  // namespace nav2_collision_monitor

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -628,18 +628,24 @@ bool VelocityPolygon::validateSteering(
   }
 
   if (valid_bucket == nullptr) {
-    // No valid bucket exists → STOP
-    robot_action.req_vel.x = 0.0;
-    robot_action.req_vel.y = 0.0;
-    robot_action.req_vel.tw = 0.0;
-    robot_action.polygon_name = polygon_name_;
-    robot_action.action_type = STOP;
-    return true;
+    // All buckets in collision — use the slowest bucket in the target direction
+    // (allowed even if in collision)
+    valid_bucket = target_buckets[0];  // sorted ascending, index 0 is slowest
   }
 
-  // 4. Decelerate to valid bucket
-  // Limit steering angle to boundary of current bucket (toward target direction)
-  if (current_bucket != nullptr) {
+  // 4. Adapt speed and steering angle
+  // 4a. Limit target speed to valid bucket's linear_max (converted to baselink)
+  double valid_max_baselink = steeringToBaselinkSpeed(
+    valid_bucket->linear_max_, target_steering_angle);
+  if (std::abs(result_vel.x) > std::abs(valid_max_baselink)) {
+    result_vel.x = (result_vel.x >= 0) ? std::abs(valid_max_baselink) :
+      -std::abs(valid_max_baselink);
+  }
+
+  // 4b. Only limit steering angle if current speed is larger than max valid speed
+  double current_baselink_abs = std::abs(current_speed);
+  double valid_max_baselink_abs = std::abs(valid_max_baselink);
+  if (current_baselink_abs > valid_max_baselink_abs && current_bucket != nullptr) {
     double limited_sa;
     if (target_steering_angle > current_sa) {
       limited_sa = current_bucket->steering_angle_max_;
@@ -647,24 +653,6 @@ bool VelocityPolygon::validateSteering(
       limited_sa = current_bucket->steering_angle_min_;
     }
     result_vel.tw = steeringAngleToTw(result_vel.x, limited_sa);
-  }
-
-  // Limit speed to valid bucket's linear_max (converted to baselink)
-  double valid_max_baselink = steeringToBaselinkSpeed(
-    valid_bucket->linear_max_, target_steering_angle);
-  if (std::abs(result_vel.x) > std::abs(valid_max_baselink)) {
-    result_vel.x = (result_vel.x >= 0) ? std::abs(valid_max_baselink) :
-      -std::abs(valid_max_baselink);
-    // Recalculate tw for the new speed
-    if (current_bucket != nullptr) {
-      double limited_sa;
-      if (target_steering_angle > current_sa) {
-        limited_sa = current_bucket->steering_angle_max_;
-      } else {
-        limited_sa = current_bucket->steering_angle_min_;
-      }
-      result_vel.tw = steeringAngleToTw(result_vel.x, limited_sa);
-    }
   }
 
   robot_action.req_vel = result_vel;

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -549,7 +549,7 @@ bool VelocityPolygon::validateSteering(
     "[%s] validateSteering: target_sw_speed=%.3f, current_sw_speed=%.3f, "
     "current_field=%s",
     polygon_name_.c_str(), target_sw_speed, current_sw_speed,
-    current_field ? current_field->sub_polygon_name_.c_str() : "null");
+    current_field ? current_field->velocity_polygon_name_.c_str() : "null");
 
   // 2. Check if target angle is in same bucket (angle range) as current
   bool same_bucket = current_field != nullptr &&
@@ -585,7 +585,7 @@ bool VelocityPolygon::validateSteering(
                 logger_,
                 "[%s] validateSteering: same_bucket speed limit — next field '%s' in collision, "
                 "limiting vel.x from %.3f to %.3f (sw_limit=%.3f)",
-                polygon_name_.c_str(), next_field->sub_polygon_name_.c_str(),
+                polygon_name_.c_str(), next_field->velocity_polygon_name_.c_str(),
                 result_vel.x, max_baselink, limit_sw);
               result_vel.x = max_baselink;
               result_vel.tw = steeringAngleToTw(result_vel.x, target_steering_angle);
@@ -670,12 +670,12 @@ bool VelocityPolygon::validateSteering(
       logger_,
       "[%s] validateSteering: all neighbour fields in collision, "
       "falling back to slowest field '%s'",
-      polygon_name_.c_str(), valid_field->sub_polygon_name_.c_str());
+      polygon_name_.c_str(), valid_field->velocity_polygon_name_.c_str());
   } else {
     RCLCPP_INFO(
       logger_,
       "[%s] validateSteering: valid neighbour field found: '%s'",
-      polygon_name_.c_str(), valid_field->sub_polygon_name_.c_str());
+      polygon_name_.c_str(), valid_field->velocity_polygon_name_.c_str());
   }
 
   // 4. Adapt speed and steering angle

--- a/nav2_collision_monitor/test/collision_monitor_node_test.cpp
+++ b/nav2_collision_monitor/test/collision_monitor_node_test.cpp
@@ -461,43 +461,6 @@ void Tester::addPolygonVelocitySubPolygon(
     rclcpp::Parameter(polygon_name + "." + sub_polygon_name + ".theta_max", theta_max));
 }
 
-void Tester::addPolygonVelocitySubPolygon(
-  const std::string & polygon_name, const std::string & sub_polygon_name,
-  const double linear_min, const double linear_max,
-  const double theta_min, const double theta_max,
-  const double size)
-{
-  const std::string points = "[[" +
-    std::to_string(size) + ", " + std::to_string(size) + "], [" +
-    std::to_string(size) + ", " + std::to_string(-size) + "], [" +
-    std::to_string(-size) + ", " + std::to_string(-size) + "], [" +
-    std::to_string(-size) + ", " + std::to_string(size) + "]]";
-  cm_->declare_parameter(
-    polygon_name + "." + sub_polygon_name + ".points", rclcpp::ParameterValue(points));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + "." + sub_polygon_name + ".points", points));
-
-  cm_->declare_parameter(
-    polygon_name + "." + sub_polygon_name + ".linear_min", rclcpp::ParameterValue(linear_min));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + "." + sub_polygon_name + ".linear_min", linear_min));
-
-  cm_->declare_parameter(
-    polygon_name + "." + sub_polygon_name + ".linear_max", rclcpp::ParameterValue(linear_max));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + "." + sub_polygon_name + ".linear_max", linear_max));
-
-  cm_->declare_parameter(
-    polygon_name + "." + sub_polygon_name + ".theta_min", rclcpp::ParameterValue(theta_min));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + "." + sub_polygon_name + ".theta_min", theta_min));
-
-  cm_->declare_parameter(
-    polygon_name + "." + sub_polygon_name + ".theta_max", rclcpp::ParameterValue(theta_max));
-  cm_->set_parameter(
-    rclcpp::Parameter(polygon_name + "." + sub_polygon_name + ".theta_max", theta_max));
-}
-
 void Tester::addSource(
   const std::string & source_name, const SourceType type)
 {

--- a/nav2_collision_monitor/test/velocity_polygons_test.cpp
+++ b/nav2_collision_monitor/test/velocity_polygons_test.cpp
@@ -1182,10 +1182,11 @@ TEST_F(Tester, testValidateSteeringDifferentBucketAllCollision)
 
   bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
   EXPECT_TRUE(modified);
-  // No valid bucket → STOP
-  EXPECT_EQ(action.action_type, nav2_collision_monitor::STOP);
-  EXPECT_NEAR(action.req_vel.x, 0.0, 1e-6);
-  EXPECT_NEAR(action.req_vel.tw, 0.0, 1e-6);
+  // All buckets in collision → use slowest bucket (allowed even if in collision), LIMIT not STOP
+  EXPECT_EQ(action.action_type, nav2_collision_monitor::LIMIT);
+  // Speed should be limited to slowest bucket's linear_max (0.5) converted to baselink
+  double expected_max = 0.5 * std::cos(target_sa);
+  EXPECT_LE(std::abs(action.req_vel.x), expected_max + 1e-3);
 }
 
 TEST_F(Tester, testValidateSteeringDecelerationToValidBucket)

--- a/nav2_collision_monitor/test/velocity_polygons_test.cpp
+++ b/nav2_collision_monitor/test/velocity_polygons_test.cpp
@@ -145,9 +145,14 @@ public:
     return current_steering_angle_;
   }
 
-  double callBaselinkToSteeringSpeed(double baselink_speed, double steering_angle) const
+  double callComputeSteeringAngle(const nav2_collision_monitor::Velocity & vel) const
   {
-    return baselinkToSteeringSpeed(baselink_speed, steering_angle);
+    return computeSteeringAngle(vel);
+  }
+
+  double callBaselinkToSteeringSpeed(double linear_vel, double angular_vel) const
+  {
+    return baselinkToSteeringSpeed(linear_vel, angular_vel);
   }
 
   double callSteeringToBaselinkSpeed(double steering_speed, double steering_angle) const
@@ -160,15 +165,16 @@ public:
     return steeringAngleToTw(baselink_speed, steering_angle);
   }
 
-  const SubPolygonParameter * callFindBucket(
+  const SubPolygonParameter * callFindField(
     double steering_wheel_speed, double steering_angle) const
   {
-    return findBucket(steering_wheel_speed, steering_angle);
+    return findField(steering_wheel_speed, steering_angle);
   }
 
-  std::vector<const SubPolygonParameter *> callFindBucketsForAngle(double steering_angle) const
+  std::vector<const SubPolygonParameter *> callFindFieldsForAngle(
+    double steering_angle, bool forward) const
   {
-    return findBucketsForAngle(steering_angle);
+    return findFieldsForAngle(steering_angle, forward);
   }
 
   static bool callIsPointInsidePoly(
@@ -734,10 +740,10 @@ TEST_F(Tester, testVelocityPolygonHolonomicVelocitySwitching)
 // Polygon for steering tests: a simple square around the robot
 static const char STEERING_POLYGON_STR[]{
   "[[1.0, 0.5], [1.0, -0.5], [-0.5, -0.5], [-0.5, 0.5]]"};
-// Smaller polygon for the slower bucket
+// Smaller polygon for the slower field
 static const char STEERING_POLYGON_SLOW_STR[]{
   "[[0.5, 0.3], [0.5, -0.3], [-0.3, -0.3], [-0.3, 0.3]]"};
-// Larger polygon for the faster bucket
+// Larger polygon for the faster field
 static const char STEERING_POLYGON_FAST_STR[]{
   "[[1.5, 0.8], [1.5, -0.8], [-0.8, -0.8], [-0.8, 0.8]]"};
 
@@ -752,20 +758,23 @@ TEST_F(Tester, testBaselinkToSteeringSpeedConversion)
   addSteeringAngleSubPolygon("fast", 0.5, 1.0, -0.5, 0.5, STEERING_POLYGON_FAST_STR);
   createSteeringVelocityPolygon("limit");
 
-  // At zero steering angle, steering speed == baselink speed
+  // At zero angular vel, steering speed == baselink speed
   EXPECT_NEAR(velocity_polygon_->callBaselinkToSteeringSpeed(1.0, 0.0), 1.0, 1e-6);
   EXPECT_NEAR(velocity_polygon_->callBaselinkToSteeringSpeed(-0.5, 0.0), -0.5, 1e-6);
 
-  // At 60 degrees, cos(60°)=0.5, so steering speed = baselink / 0.5 = 2*baselink
-  EXPECT_NEAR(velocity_polygon_->callBaselinkToSteeringSpeed(1.0, M_PI / 3), 2.0, 1e-6);
+  // At 60 deg steering: tw = vx * tan(60°) / wheelbase = sqrt(3), expected = hypot(1, sqrt(3)) = 2
+  EXPECT_NEAR(velocity_polygon_->callBaselinkToSteeringSpeed(1.0, std::sqrt(3.0)), 2.0, 1e-6);
 
-  // At 45 degrees, cos(45°)=sqrt(2)/2 ≈ 0.7071
-  double expected = 1.0 / std::cos(M_PI / 4);
-  EXPECT_NEAR(velocity_polygon_->callBaselinkToSteeringSpeed(1.0, M_PI / 4), expected, 1e-6);
+  // At 45 deg steering: tw = vx * tan(45°) / wheelbase = 1.0, expected = hypot(1, 1) = sqrt(2)
+  double expected = std::sqrt(2.0);
+  EXPECT_NEAR(velocity_polygon_->callBaselinkToSteeringSpeed(1.0, 1.0), expected, 1e-6);
 
-  // Near 90 degrees should return a very large value (guard)
-  double result = velocity_polygon_->callBaselinkToSteeringSpeed(1.0, M_PI / 2);
-  EXPECT_GT(std::abs(result), 1e5);
+  // At 90 deg steering (vx=0, tw!=0): continuous result, not infinity
+  double result = velocity_polygon_->callBaselinkToSteeringSpeed(0.0, 1.0);
+  EXPECT_NEAR(result, WHEELBASE * 1.0, 1e-6);
+
+  // Negative speed: sign is preserved
+  EXPECT_NEAR(velocity_polygon_->callBaselinkToSteeringSpeed(-1.0, 1.0), -expected, 1e-6);
 }
 
 TEST_F(Tester, testSteeringToBaselinkSpeedConversion)
@@ -781,9 +790,11 @@ TEST_F(Tester, testSteeringToBaselinkSpeedConversion)
   EXPECT_NEAR(velocity_polygon_->callSteeringToBaselinkSpeed(1.0, M_PI / 3), 0.5, 1e-6);
 
   // Roundtrip: baselink -> steering -> baselink should be identity
-  double sa = 0.3;
+  double sa = 0.3;  // steering angle
   double baselink = 0.8;
-  double steering = velocity_polygon_->callBaselinkToSteeringSpeed(baselink, sa);
+  // tw = |vx| * tan(sa) / wheelbase (for vx > 0, wheelbase = 1.0)
+  double tw = baselink * std::tan(sa) / WHEELBASE;
+  double steering = velocity_polygon_->callBaselinkToSteeringSpeed(baselink, tw);
   double roundtrip = velocity_polygon_->callSteeringToBaselinkSpeed(steering, sa);
   EXPECT_NEAR(roundtrip, baselink, 1e-6);
 }
@@ -811,7 +822,7 @@ TEST_F(Tester, testSteeringAngleToTw)
 
 TEST_F(Tester, testIsInRangeWithSteeringWheelSpeed)
 {
-  // Setup: 2 speed buckets with steering angle params
+  // Setup: 2 speed fields with steering angle params
   // Slow: 0.0 to 0.5 steering wheel speed, steering angle -0.5 to 0.5
   // Fast: 0.5 to 1.0 steering wheel speed, steering angle -0.5 to 0.5
   setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow", "fast"});
@@ -820,12 +831,12 @@ TEST_F(Tester, testIsInRangeWithSteeringWheelSpeed)
   createSteeringVelocityPolygon("limit");
 
   // With zero steering angle: baselink speed == steering wheel speed
-  // 0.3 m/s baselink → 0.3 steering → should be "slow" bucket
+  // 0.3 m/s baselink → 0.3 steering → should be "slow" field
   nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
   velocity_polygon_->updatePolygon(vel);
   EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "slow");
 
-  // 0.7 m/s baselink → 0.7 steering → should be "fast" bucket
+  // 0.7 m/s baselink → 0.7 steering → should be "fast" field
   vel = {0.7, 0.0, 0.0};
   velocity_polygon_->updatePolygon(vel);
   EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "fast");
@@ -833,7 +844,7 @@ TEST_F(Tester, testIsInRangeWithSteeringWheelSpeed)
   // With non-zero steering angle, the baselink speed that maps to a given
   // steering wheel speed is lower. E.g., at 0.3 rad steering angle:
   // v_steering = v_baselink / cos(0.3) ≈ v_baselink / 0.9553
-  // So 0.48 baselink → 0.48 / 0.9553 ≈ 0.502 steering → "fast" bucket
+  // So 0.48 baselink → 0.48 / 0.9553 ≈ 0.502 steering → "fast" field
   // We need to set tw correctly: tw = tan(sa) * |v| / wheelbase
   double sa = 0.3;
   double v_base = 0.48;
@@ -842,7 +853,7 @@ TEST_F(Tester, testIsInRangeWithSteeringWheelSpeed)
   velocity_polygon_->updatePolygon(vel);
   EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "fast");
 
-  // With same steering angle, 0.45 baselink → 0.45 / 0.9553 ≈ 0.471 steering → "slow" bucket
+  // With same steering angle, 0.45 baselink → 0.45 / 0.9553 ≈ 0.471 steering → "slow" field
   v_base = 0.45;
   tw = std::tan(sa) * std::abs(v_base) / WHEELBASE;
   vel = {v_base, 0.0, tw};
@@ -932,55 +943,55 @@ TEST_F(Tester, testGetPointsInsideSubPolygon)
   EXPECT_EQ(count, 2);
 }
 
-TEST_F(Tester, testFindBucket)
+TEST_F(Tester, testFindField)
 {
   setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow", "fast"});
   addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
   addSteeringAngleSubPolygon("fast", 0.5, 1.0, -0.5, 0.5, STEERING_POLYGON_FAST_STR);
   createSteeringVelocityPolygon("limit");
 
-  // Find bucket for 0.3 speed at 0 angle → slow
-  auto bucket = velocity_polygon_->callFindBucket(0.3, 0.0);
-  ASSERT_NE(bucket, nullptr);
-  EXPECT_EQ(bucket->velocity_polygon_name_, "slow");
+  // Find field for 0.3 speed at 0 angle → slow
+  auto field = velocity_polygon_->callFindField(0.3, 0.0);
+  ASSERT_NE(field, nullptr);
+  EXPECT_EQ(field->velocity_polygon_name_, "slow");
 
-  // Find bucket for 0.7 speed at 0 angle → fast
-  bucket = velocity_polygon_->callFindBucket(0.7, 0.0);
-  ASSERT_NE(bucket, nullptr);
-  EXPECT_EQ(bucket->velocity_polygon_name_, "fast");
+  // Find field for 0.7 speed at 0 angle → fast
+  field = velocity_polygon_->callFindField(0.7, 0.0);
+  ASSERT_NE(field, nullptr);
+  EXPECT_EQ(field->velocity_polygon_name_, "fast");
 
   // Out of range speed
-  bucket = velocity_polygon_->callFindBucket(1.5, 0.0);
-  EXPECT_EQ(bucket, nullptr);
+  field = velocity_polygon_->callFindField(1.5, 0.0);
+  EXPECT_EQ(field, nullptr);
 
   // Out of range angle
-  bucket = velocity_polygon_->callFindBucket(0.3, 1.0);
-  EXPECT_EQ(bucket, nullptr);
+  field = velocity_polygon_->callFindField(0.3, 1.0);
+  EXPECT_EQ(field, nullptr);
 }
 
-TEST_F(Tester, testFindBucketsForAngle)
+TEST_F(Tester, testFindFieldsForAngle)
 {
   setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow", "fast"});
   addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
   addSteeringAngleSubPolygon("fast", 0.5, 1.0, -0.5, 0.5, STEERING_POLYGON_FAST_STR);
   createSteeringVelocityPolygon("limit");
 
-  // At angle 0, both buckets should match, sorted by linear_min ascending
-  auto buckets = velocity_polygon_->callFindBucketsForAngle(0.0);
-  ASSERT_EQ(buckets.size(), 2u);
-  EXPECT_EQ(buckets[0]->velocity_polygon_name_, "slow");
-  EXPECT_EQ(buckets[1]->velocity_polygon_name_, "fast");
+  // At angle 0, both forward fields should match, sorted by linear_min ascending
+  auto fields = velocity_polygon_->callFindFieldsForAngle(0.0, true);
+  ASSERT_EQ(fields.size(), 2u);
+  EXPECT_EQ(fields[0]->velocity_polygon_name_, "slow");
+  EXPECT_EQ(fields[1]->velocity_polygon_name_, "fast");
 
-  // At angle 1.0 (outside range), no buckets
-  buckets = velocity_polygon_->callFindBucketsForAngle(1.0);
-  EXPECT_EQ(buckets.size(), 0u);
+  // At angle 1.0 (outside range), no fields
+  fields = velocity_polygon_->callFindFieldsForAngle(1.0, true);
+  EXPECT_EQ(fields.size(), 0u);
 }
 
 // ==================== validateSteering tests ====================
 
 TEST_F(Tester, testValidateSteeringDirectionReversalHighSpeed)
 {
-  // Setup: 2 speed buckets with steering angle
+  // Setup: 2 speed fields with steering angle
   setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow", "fast"});
   addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
   addSteeringAngleSubPolygon("fast", 0.5, 1.0, -0.5, 0.5, STEERING_POLYGON_FAST_STR);
@@ -1049,7 +1060,7 @@ TEST_F(Tester, testValidateSteeringBothBelowThreshold)
   EXPECT_FALSE(modified);
 }
 
-TEST_F(Tester, testValidateSteeringSameBucketAcceleratingNoCollision)
+TEST_F(Tester, testValidateSteeringSameBucketResultStaysInField)
 {
   setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow", "fast"});
   addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
@@ -1059,9 +1070,9 @@ TEST_F(Tester, testValidateSteeringSameBucketAcceleratingNoCollision)
   nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
   velocity_polygon_->updatePolygon(vel);
 
-  // Same bucket, accelerating, no collision in next bucket → no modification
-  nav2_collision_monitor::Velocity cmd_vel{0.4, 0.0, 0.0};  // target in slow bucket
-  nav2_collision_monitor::Velocity odom_vel{0.2, 0.0, 0.0};  // current in slow bucket
+  // Same field, result velocity stays in same field, no collision check needed → no modification
+  nav2_collision_monitor::Velocity cmd_vel{0.4, 0.0, 0.0};  // target in slow field
+  nav2_collision_monitor::Velocity odom_vel{0.2, 0.0, 0.0};  // current in slow field
   std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
   collision_map["source"] = {};  // no collision points
 
@@ -1072,7 +1083,7 @@ TEST_F(Tester, testValidateSteeringSameBucketAcceleratingNoCollision)
   EXPECT_FALSE(modified);
 }
 
-TEST_F(Tester, testValidateSteeringSameBucketAcceleratingWithCollision)
+TEST_F(Tester, testValidateSteeringSameBucketFasterFieldCollision)
 {
   setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow", "fast"});
   addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
@@ -1082,25 +1093,12 @@ TEST_F(Tester, testValidateSteeringSameBucketAcceleratingWithCollision)
   nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
   velocity_polygon_->updatePolygon(vel);
 
-  // Same bucket, accelerating, collision in next (fast) bucket → limit speed
-  // Use a high target speed that exceeds the slow bucket's max (0.5) after conversion,
-  // but still falls in the slow bucket because at non-zero steering angle sw speed is higher.
-  // At steering angle 0.3: sw_speed = 0.48 / cos(0.3) ≈ 0.503 → still slow bucket?
-  // Actually, let's use straight movement and a cmd_vel that tries to go to 0.6
-  // which would be in the fast bucket — wait, that's a different bucket test.
-  //
-  // The correct test: when in slow bucket and accelerating toward the upper limit,
-  // if there's collision in the fast bucket, the speed should be capped at slow bucket max.
-  // We need result_vel.x > slow_max for the limit to kick in.
-  // Set cmd_vel.x = 0.6 (which maps to fast bucket for target) — but then
-  // target_bucket != current_bucket and we'd be in the different-bucket branch.
-  //
-  // For the same-bucket case to limit, both must be in the same bucket AND
-  // the output velocity must exceed the bucket max. This happens when Step 1
-  // (the main polygon loop) didn't limit, but the steering check wants to cap.
-  // Use a robot_action that already has higher velocity from prior processing.
-  nav2_collision_monitor::Velocity cmd_vel{0.4, 0.0, 0.0};  // target in slow bucket
-  nav2_collision_monitor::Velocity odom_vel{0.2, 0.0, 0.0};  // current in slow bucket
+  // Same field (cmd_vel maps to slow field), but result velocity from prior processing
+  // falls in the next faster (fast) field which has collision → limit speed.
+  // The steering check sees result_vel is in a different field than current, checks
+  // collision there, and caps speed to current field's linear_max.
+  nav2_collision_monitor::Velocity cmd_vel{0.4, 0.0, 0.0};  // target in slow field
+  nav2_collision_monitor::Velocity odom_vel{0.2, 0.0, 0.0};  // current in slow field
   std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
   // Place collision points inside the fast polygon
   collision_map["source"] = {
@@ -1108,7 +1106,7 @@ TEST_F(Tester, testValidateSteeringSameBucketAcceleratingWithCollision)
     {1.3, 0.1},   // inside fast polygon
   };
 
-  // Set robot_action with a velocity that exceeds the slow bucket max
+  // Set robot_action with a velocity that exceeds the slow field max
   // (simulating that the main loop allowed higher speed)
   nav2_collision_monitor::Velocity action_vel{0.6, 0.0, 0.0};
   nav2_collision_monitor::Action action{
@@ -1117,14 +1115,14 @@ TEST_F(Tester, testValidateSteeringSameBucketAcceleratingWithCollision)
   bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
   EXPECT_TRUE(modified);
   EXPECT_EQ(action.action_type, nav2_collision_monitor::LIMIT);
-  // Speed should be limited to slow bucket's linear_max in baselink speed
+  // Speed should be limited to slow field's linear_max in baselink speed
   // At 0 steering angle, that's just 0.5
   EXPECT_LE(std::abs(action.req_vel.x), 0.5 + 1e-6);
 }
 
 TEST_F(Tester, testValidateSteeringDifferentBucketCollisionFree)
 {
-  // Buckets at different steering angles
+  // Fields at different steering angles
   setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD,
     {"straight_slow", "straight_fast", "left_slow", "left_fast"});
   addSteeringAngleSubPolygon("straight_slow", 0.0, 0.5, -0.1, 0.1, STEERING_POLYGON_SLOW_STR);
@@ -1149,12 +1147,12 @@ TEST_F(Tester, testValidateSteeringDifferentBucketCollisionFree)
     nav2_collision_monitor::DO_NOTHING, cmd_vel, ""};
 
   bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
-  EXPECT_FALSE(modified);  // fastest bucket is collision-free → done
+  EXPECT_FALSE(modified);  // fastest field is collision-free → done
 }
 
 TEST_F(Tester, testValidateSteeringDifferentBucketAllCollision)
 {
-  // Buckets at different steering angles
+  // Fields at different steering angles
   setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD,
     {"straight_slow", "left_slow"});
   addSteeringAngleSubPolygon("straight_slow", 0.0, 0.5, -0.1, 0.1, STEERING_POLYGON_SLOW_STR);
@@ -1171,7 +1169,7 @@ TEST_F(Tester, testValidateSteeringDifferentBucketAllCollision)
   nav2_collision_monitor::Velocity cmd_vel{0.3, 0.0, target_tw};
 
   std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
-  // Collision in all left buckets
+  // Collision in all left fields
   collision_map["source"] = {
     {0.0, 0.0},
     {0.2, 0.1},
@@ -1182,16 +1180,18 @@ TEST_F(Tester, testValidateSteeringDifferentBucketAllCollision)
 
   bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
   EXPECT_TRUE(modified);
-  // All buckets in collision → use slowest bucket (allowed even if in collision), LIMIT not STOP
+  // All fields in collision → use slowest field (allowed even if in collision), LIMIT not STOP
   EXPECT_EQ(action.action_type, nav2_collision_monitor::LIMIT);
-  // Speed should be limited to slowest bucket's linear_max (0.5) converted to baselink
-  double expected_max = 0.5 * std::cos(target_sa);
+  // Speed should be limited to slowest field's linear_max (0.5) converted to baselink
+  // At the neighbour bucket boundary (0.1 rad)
+  double neighbour_angle = 0.1;  // straight bucket boundary toward left
+  double expected_max = 0.5 * std::cos(neighbour_angle);
   EXPECT_LE(std::abs(action.req_vel.x), expected_max + 1e-3);
 }
 
-TEST_F(Tester, testValidateSteeringDecelerationToValidBucket)
+TEST_F(Tester, testValidateSteeringDifferentBucketDecelerationToValidField)
 {
-  // Setup: straight and left, each with slow and fast buckets
+  // Setup: straight and left, each with slow and fast fields
   setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD,
     {"straight_slow", "straight_fast", "left_slow", "left_fast"});
   addSteeringAngleSubPolygon("straight_slow", 0.0, 0.5, -0.1, 0.1, STEERING_POLYGON_SLOW_STR);
@@ -1203,7 +1203,7 @@ TEST_F(Tester, testValidateSteeringDecelerationToValidBucket)
   nav2_collision_monitor::Velocity vel{0.7, 0.0, 0.0};
   velocity_polygon_->updatePolygon(vel);
 
-  // Current: straight at 0.7 (fast bucket), Target: left at 0.7 (fast bucket)
+  // Current: straight at 0.7 (fast field), Target: left at 0.7 (fast field)
   nav2_collision_monitor::Velocity odom_vel{0.7, 0.0, 0.0};
   double target_sa = 0.3;
   double target_tw = std::tan(target_sa) * 0.7 / WHEELBASE;
@@ -1222,10 +1222,47 @@ TEST_F(Tester, testValidateSteeringDecelerationToValidBucket)
   bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
   EXPECT_TRUE(modified);
   EXPECT_EQ(action.action_type, nav2_collision_monitor::LIMIT);
-  // Speed should be limited to slow bucket's linear_max (0.5) converted to baselink
-  // At the target angle, baselink = 0.5 * cos(target_sa)
-  double expected_max = 0.5 * std::cos(target_sa);
+  // Speed should be limited to slow field's linear_max (0.5) converted to baselink
+  // At the neighbour bucket boundary (0.1 rad), baselink = 0.5 * cos(0.1)
+  double neighbour_angle = 0.1;  // straight bucket boundary toward left
+  double expected_max = 0.5 * std::cos(neighbour_angle);
   EXPECT_LE(std::abs(action.req_vel.x), expected_max + 1e-3);
+}
+
+TEST_F(Tester, testValidateSteeringBackwardSameBucketFasterFieldCollision)
+{
+  // Two backward fields in the same bucket:
+  // backward_slow: [-0.3, 0.0], backward_mid: [-0.7, -0.3]
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD,
+    {"backward_slow", "backward_mid"});
+  addSteeringAngleSubPolygon("backward_slow", -0.3, 0.0, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
+  addSteeringAngleSubPolygon("backward_mid", -0.7, -0.3, -0.5, 0.5, STEERING_POLYGON_FAST_STR);
+  createSteeringVelocityPolygon("limit");
+
+  nav2_collision_monitor::Velocity vel{-0.2, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+
+  // cmd_vel and odom both in backward_slow field
+  nav2_collision_monitor::Velocity cmd_vel{-0.2, 0.0, 0.0};
+  nav2_collision_monitor::Velocity odom_vel{-0.1, 0.0, 0.0};
+  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
+  // Collision points inside the backward_mid (larger) polygon
+  collision_map["source"] = {
+    {-0.6, 0.0},
+    {-0.7, 0.1},
+  };
+
+  // result velocity from prior processing falls in backward_mid field
+  nav2_collision_monitor::Velocity action_vel{-0.5, 0.0, 0.0};
+  nav2_collision_monitor::Action action{
+    nav2_collision_monitor::DO_NOTHING, action_vel, ""};
+
+  bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
+  EXPECT_TRUE(modified);
+  EXPECT_EQ(action.action_type, nav2_collision_monitor::LIMIT);
+  // Speed should be limited to backward_slow's linear_min (-0.3) converted to baselink
+  // At 0 steering angle, that's -0.3
+  EXPECT_GE(action.req_vel.x, -0.3 - 1e-6);  // not more negative than -0.3
 }
 
 TEST_F(Tester, testValidateSteeringNotApplicableToNonSteering)

--- a/nav2_collision_monitor/test/velocity_polygons_test.cpp
+++ b/nav2_collision_monitor/test/velocity_polygons_test.cpp
@@ -19,6 +19,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -138,6 +139,52 @@ public:
   {
     return sub_polygons_;
   }
+
+  double getCurrentSteeringAngle() const
+  {
+    return current_steering_angle_;
+  }
+
+  double callBaselinkToSteeringSpeed(double baselink_speed, double steering_angle) const
+  {
+    return baselinkToSteeringSpeed(baselink_speed, steering_angle);
+  }
+
+  double callSteeringToBaselinkSpeed(double steering_speed, double steering_angle) const
+  {
+    return steeringToBaselinkSpeed(steering_speed, steering_angle);
+  }
+
+  double callSteeringAngleToTw(double baselink_speed, double steering_angle) const
+  {
+    return steeringAngleToTw(baselink_speed, steering_angle);
+  }
+
+  const SubPolygonParameter * callFindBucket(
+    double steering_wheel_speed, double steering_angle) const
+  {
+    return findBucket(steering_wheel_speed, steering_angle);
+  }
+
+  std::vector<const SubPolygonParameter *> callFindBucketsForAngle(double steering_angle) const
+  {
+    return findBucketsForAngle(steering_angle);
+  }
+
+  static bool callIsPointInsidePoly(
+    const nav2_collision_monitor::Point & point,
+    const std::vector<nav2_collision_monitor::Point> & vertices)
+  {
+    return isPointInsidePoly(point, vertices);
+  }
+
+  int callGetPointsInsideSubPolygon(
+    const SubPolygonParameter & sub_polygon,
+    const std::unordered_map<std::string,
+    std::vector<nav2_collision_monitor::Point>> & collision_points_map) const
+  {
+    return getPointsInsideSubPolygon(sub_polygon, collision_points_map);
+  }
 };  // VelocityPolygonWrapper
 
 class Tester : public ::testing::Test
@@ -161,8 +208,18 @@ protected:
     const double direction_end_angle, const double direction_start_angle,
     const std::string & polygon_points, const bool is_holonomic);
 
+  void addSteeringAngleSubPolygon(
+    const std::string & sub_polygon_name,
+    const double linear_min, const double linear_max,
+    const double steering_angle_min, const double steering_angle_max,
+    const std::string & polygon_points);
+  void setSteeringVelocityPolygonParameters(
+    const double wheelbase, const double low_speed_threshold,
+    const std::vector<std::string> & sub_polygon_names);
+
   // Creating routines
   void createVelocityPolygon(const std::string & action_type, const bool is_holonomic);
+  void createSteeringVelocityPolygon(const std::string & action_type);
 
   // Wait until polygon will be received
   bool waitPolygon(
@@ -385,6 +442,79 @@ void Tester::addPolygonVelocitySubPolygon(
   }
 }
 
+void Tester::addSteeringAngleSubPolygon(
+  const std::string & sub_polygon_name,
+  const double linear_min, const double linear_max,
+  const double steering_angle_min, const double steering_angle_max,
+  const std::string & polygon_points)
+{
+  const std::string prefix = std::string(POLYGON_NAME) + "." + sub_polygon_name;
+
+  test_node_->declare_parameter(
+    prefix + ".points", rclcpp::ParameterValue(polygon_points));
+  test_node_->set_parameter(
+    rclcpp::Parameter(prefix + ".points", polygon_points));
+
+  test_node_->declare_parameter(
+    prefix + ".linear_min", rclcpp::ParameterValue(linear_min));
+  test_node_->set_parameter(
+    rclcpp::Parameter(prefix + ".linear_min", linear_min));
+
+  test_node_->declare_parameter(
+    prefix + ".linear_max", rclcpp::ParameterValue(linear_max));
+  test_node_->set_parameter(
+    rclcpp::Parameter(prefix + ".linear_max", linear_max));
+
+  test_node_->declare_parameter(
+    prefix + ".steering_angle_min", rclcpp::ParameterValue(steering_angle_min));
+  test_node_->set_parameter(
+    rclcpp::Parameter(prefix + ".steering_angle_min", steering_angle_min));
+
+  test_node_->declare_parameter(
+    prefix + ".steering_angle_max", rclcpp::ParameterValue(steering_angle_max));
+  test_node_->set_parameter(
+    rclcpp::Parameter(prefix + ".steering_angle_max", steering_angle_max));
+}
+
+void Tester::setSteeringVelocityPolygonParameters(
+  const double wheelbase, const double low_speed_threshold,
+  const std::vector<std::string> & sub_polygon_names)
+{
+  test_node_->declare_parameter(
+    std::string(POLYGON_NAME) + ".holonomic", rclcpp::ParameterValue(false));
+  test_node_->set_parameter(
+    rclcpp::Parameter(std::string(POLYGON_NAME) + ".holonomic", false));
+
+  test_node_->declare_parameter(
+    std::string(POLYGON_NAME) + ".wheelbase", rclcpp::ParameterValue(wheelbase));
+  test_node_->set_parameter(
+    rclcpp::Parameter(std::string(POLYGON_NAME) + ".wheelbase", wheelbase));
+
+  test_node_->declare_parameter(
+    std::string(POLYGON_NAME) + ".low_speed_threshold",
+    rclcpp::ParameterValue(low_speed_threshold));
+  test_node_->set_parameter(
+    rclcpp::Parameter(
+      std::string(POLYGON_NAME) + ".low_speed_threshold", low_speed_threshold));
+
+  test_node_->declare_parameter(
+    std::string(POLYGON_NAME) + ".velocity_polygons",
+    rclcpp::ParameterValue(sub_polygon_names));
+  test_node_->set_parameter(
+    rclcpp::Parameter(std::string(POLYGON_NAME) + ".velocity_polygons", sub_polygon_names));
+}
+
+void Tester::createSteeringVelocityPolygon(const std::string & action_type)
+{
+  setCommonParameters(POLYGON_NAME, action_type);
+
+  velocity_polygon_ = std::make_shared<VelocityPolygonWrapper>(
+    test_node_, POLYGON_NAME,
+    tf_buffer_, BASE_FRAME_ID, TRANSFORM_TOLERANCE);
+  ASSERT_TRUE(velocity_polygon_->configure());
+  velocity_polygon_->activate();
+}
+
 void Tester::createVelocityPolygon(const std::string & action_type, const bool is_holonomic)
 {
   setCommonParameters(POLYGON_NAME, action_type);
@@ -596,6 +726,522 @@ TEST_F(Tester, testVelocityPolygonHolonomicVelocitySwitching)
   EXPECT_NEAR(poly[2].y, RIGHT_POLYGON[5], EPSILON);
   EXPECT_NEAR(poly[3].x, RIGHT_POLYGON[6], EPSILON);
   EXPECT_NEAR(poly[3].y, RIGHT_POLYGON[7], EPSILON);
+}
+
+
+// ==================== Steering wheel speed conversion tests ====================
+
+// Polygon for steering tests: a simple square around the robot
+static const char STEERING_POLYGON_STR[]{
+  "[[1.0, 0.5], [1.0, -0.5], [-0.5, -0.5], [-0.5, 0.5]]"};
+// Smaller polygon for the slower bucket
+static const char STEERING_POLYGON_SLOW_STR[]{
+  "[[0.5, 0.3], [0.5, -0.3], [-0.3, -0.3], [-0.3, 0.3]]"};
+// Larger polygon for the faster bucket
+static const char STEERING_POLYGON_FAST_STR[]{
+  "[[1.5, 0.8], [1.5, -0.8], [-0.8, -0.8], [-0.8, 0.8]]"};
+
+static const double WHEELBASE{1.0};
+static const double LOW_SPEED_THRESHOLD{0.1};
+
+TEST_F(Tester, testBaselinkToSteeringSpeedConversion)
+{
+  // Setup: create a simple steering velocity polygon
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow", "fast"});
+  addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
+  addSteeringAngleSubPolygon("fast", 0.5, 1.0, -0.5, 0.5, STEERING_POLYGON_FAST_STR);
+  createSteeringVelocityPolygon("limit");
+
+  // At zero steering angle, steering speed == baselink speed
+  EXPECT_NEAR(velocity_polygon_->callBaselinkToSteeringSpeed(1.0, 0.0), 1.0, 1e-6);
+  EXPECT_NEAR(velocity_polygon_->callBaselinkToSteeringSpeed(-0.5, 0.0), -0.5, 1e-6);
+
+  // At 60 degrees, cos(60°)=0.5, so steering speed = baselink / 0.5 = 2*baselink
+  EXPECT_NEAR(velocity_polygon_->callBaselinkToSteeringSpeed(1.0, M_PI / 3), 2.0, 1e-6);
+
+  // At 45 degrees, cos(45°)=sqrt(2)/2 ≈ 0.7071
+  double expected = 1.0 / std::cos(M_PI / 4);
+  EXPECT_NEAR(velocity_polygon_->callBaselinkToSteeringSpeed(1.0, M_PI / 4), expected, 1e-6);
+
+  // Near 90 degrees should return a very large value (guard)
+  double result = velocity_polygon_->callBaselinkToSteeringSpeed(1.0, M_PI / 2);
+  EXPECT_GT(std::abs(result), 1e5);
+}
+
+TEST_F(Tester, testSteeringToBaselinkSpeedConversion)
+{
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow"});
+  addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
+  createSteeringVelocityPolygon("limit");
+
+  // At zero steering angle, baselink speed == steering speed
+  EXPECT_NEAR(velocity_polygon_->callSteeringToBaselinkSpeed(1.0, 0.0), 1.0, 1e-6);
+
+  // At 60 degrees, cos(60°)=0.5, so baselink = steering * 0.5
+  EXPECT_NEAR(velocity_polygon_->callSteeringToBaselinkSpeed(1.0, M_PI / 3), 0.5, 1e-6);
+
+  // Roundtrip: baselink -> steering -> baselink should be identity
+  double sa = 0.3;
+  double baselink = 0.8;
+  double steering = velocity_polygon_->callBaselinkToSteeringSpeed(baselink, sa);
+  double roundtrip = velocity_polygon_->callSteeringToBaselinkSpeed(steering, sa);
+  EXPECT_NEAR(roundtrip, baselink, 1e-6);
+}
+
+TEST_F(Tester, testSteeringAngleToTw)
+{
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow"});
+  addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
+  createSteeringVelocityPolygon("limit");
+
+  // At zero steering angle, tw should be 0
+  EXPECT_NEAR(velocity_polygon_->callSteeringAngleToTw(1.0, 0.0), 0.0, 1e-6);
+
+  // Forward, positive steering angle → positive tw
+  // tw = tan(angle) * |v| / wheelbase
+  double sa = 0.3;
+  double v = 1.0;
+  double expected_tw = std::tan(sa) * std::abs(v) / WHEELBASE;
+  EXPECT_NEAR(velocity_polygon_->callSteeringAngleToTw(v, sa), expected_tw, 1e-6);
+
+  // Reverse, positive steering angle → negative tw (sign-corrected for reverse)
+  double expected_tw_reverse = -(std::tan(sa) * std::abs(-v) / WHEELBASE);
+  EXPECT_NEAR(velocity_polygon_->callSteeringAngleToTw(-v, sa), expected_tw_reverse, 1e-6);
+}
+
+TEST_F(Tester, testIsInRangeWithSteeringWheelSpeed)
+{
+  // Setup: 2 speed buckets with steering angle params
+  // Slow: 0.0 to 0.5 steering wheel speed, steering angle -0.5 to 0.5
+  // Fast: 0.5 to 1.0 steering wheel speed, steering angle -0.5 to 0.5
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow", "fast"});
+  addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
+  addSteeringAngleSubPolygon("fast", 0.5, 1.0, -0.5, 0.5, STEERING_POLYGON_FAST_STR);
+  createSteeringVelocityPolygon("limit");
+
+  // With zero steering angle: baselink speed == steering wheel speed
+  // 0.3 m/s baselink → 0.3 steering → should be "slow" bucket
+  nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "slow");
+
+  // 0.7 m/s baselink → 0.7 steering → should be "fast" bucket
+  vel = {0.7, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "fast");
+
+  // With non-zero steering angle, the baselink speed that maps to a given
+  // steering wheel speed is lower. E.g., at 0.3 rad steering angle:
+  // v_steering = v_baselink / cos(0.3) ≈ v_baselink / 0.9553
+  // So 0.48 baselink → 0.48 / 0.9553 ≈ 0.502 steering → "fast" bucket
+  // We need to set tw correctly: tw = tan(sa) * |v| / wheelbase
+  double sa = 0.3;
+  double v_base = 0.48;
+  double tw = std::tan(sa) * std::abs(v_base) / WHEELBASE;
+  vel = {v_base, 0.0, tw};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "fast");
+
+  // With same steering angle, 0.45 baselink → 0.45 / 0.9553 ≈ 0.471 steering → "slow" bucket
+  v_base = 0.45;
+  tw = std::tan(sa) * std::abs(v_base) / WHEELBASE;
+  vel = {v_base, 0.0, tw};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "slow");
+}
+
+TEST_F(Tester, testLinearLimitConversionInUpdatePolygon)
+{
+  // Setup: create a LIMIT velocity polygon with steering angle
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow"});
+
+  // Add a sub-polygon with linear_limit = 0.49 (steering wheel speed)
+  const std::string prefix = std::string(POLYGON_NAME) + ".slow";
+  test_node_->declare_parameter(prefix + ".points", rclcpp::ParameterValue(
+      std::string(STEERING_POLYGON_SLOW_STR)));
+  test_node_->set_parameter(rclcpp::Parameter(prefix + ".points",
+    std::string(STEERING_POLYGON_SLOW_STR)));
+  test_node_->declare_parameter(prefix + ".linear_min", rclcpp::ParameterValue(0.0));
+  test_node_->set_parameter(rclcpp::Parameter(prefix + ".linear_min", 0.0));
+  test_node_->declare_parameter(prefix + ".linear_max", rclcpp::ParameterValue(1.0));
+  test_node_->set_parameter(rclcpp::Parameter(prefix + ".linear_max", 1.0));
+  test_node_->declare_parameter(prefix + ".steering_angle_min", rclcpp::ParameterValue(-0.5));
+  test_node_->set_parameter(rclcpp::Parameter(prefix + ".steering_angle_min", -0.5));
+  test_node_->declare_parameter(prefix + ".steering_angle_max", rclcpp::ParameterValue(0.5));
+  test_node_->set_parameter(rclcpp::Parameter(prefix + ".steering_angle_max", 0.5));
+  test_node_->declare_parameter(prefix + ".linear_limit", rclcpp::ParameterValue(0.49));
+  test_node_->set_parameter(rclcpp::Parameter(prefix + ".linear_limit", 0.49));
+  test_node_->declare_parameter(prefix + ".angular_limit", rclcpp::ParameterValue(0.5));
+  test_node_->set_parameter(rclcpp::Parameter(prefix + ".angular_limit", 0.5));
+
+  createSteeringVelocityPolygon("limit");
+
+  // At zero steering angle, linear_limit should be 0.49 * cos(0) = 0.49
+  nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_NEAR(velocity_polygon_->getLinearLimit(), 0.49, 1e-6);
+
+  // At steering angle 0.3 rad, linear_limit should be 0.49 * cos(0.3) ≈ 0.4681
+  double sa = 0.3;
+  double v_base = 0.3;
+  double tw = std::tan(sa) * std::abs(v_base) / WHEELBASE;
+  vel = {v_base, 0.0, tw};
+  velocity_polygon_->updatePolygon(vel);
+  double expected_limit = 0.49 * std::cos(sa);
+  EXPECT_NEAR(velocity_polygon_->getLinearLimit(), expected_limit, 1e-3);
+}
+
+TEST_F(Tester, testIsPointInsidePoly)
+{
+  // Simple square polygon: (-1,-1), (1,-1), (1,1), (-1,1)
+  std::vector<nav2_collision_monitor::Point> square = {
+    {-1.0, -1.0}, {1.0, -1.0}, {1.0, 1.0}, {-1.0, 1.0}
+  };
+
+  // Point inside
+  EXPECT_TRUE(VelocityPolygonWrapper::callIsPointInsidePoly({0.0, 0.0}, square));
+  EXPECT_TRUE(VelocityPolygonWrapper::callIsPointInsidePoly({0.5, 0.5}, square));
+
+  // Point outside
+  EXPECT_FALSE(VelocityPolygonWrapper::callIsPointInsidePoly({2.0, 0.0}, square));
+  EXPECT_FALSE(VelocityPolygonWrapper::callIsPointInsidePoly({0.0, 2.0}, square));
+  EXPECT_FALSE(VelocityPolygonWrapper::callIsPointInsidePoly({-2.0, -2.0}, square));
+}
+
+TEST_F(Tester, testGetPointsInsideSubPolygon)
+{
+  // Setup a steering velocity polygon
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow"});
+  // Use a polygon that covers (-0.3,-0.3) to (0.5,0.3)
+  addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
+  createSteeringVelocityPolygon("limit");
+
+  auto sub_polygons = velocity_polygon_->getSubPolygons();
+  ASSERT_EQ(sub_polygons.size(), 1u);
+
+  // Create collision points: some inside, some outside
+  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
+  collision_map["source"] = {
+    {0.0, 0.0},     // inside
+    {0.2, 0.1},     // inside
+    {10.0, 10.0},   // outside
+    {-10.0, -10.0}  // outside
+  };
+
+  int count = velocity_polygon_->callGetPointsInsideSubPolygon(sub_polygons[0], collision_map);
+  EXPECT_EQ(count, 2);
+}
+
+TEST_F(Tester, testFindBucket)
+{
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow", "fast"});
+  addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
+  addSteeringAngleSubPolygon("fast", 0.5, 1.0, -0.5, 0.5, STEERING_POLYGON_FAST_STR);
+  createSteeringVelocityPolygon("limit");
+
+  // Find bucket for 0.3 speed at 0 angle → slow
+  auto bucket = velocity_polygon_->callFindBucket(0.3, 0.0);
+  ASSERT_NE(bucket, nullptr);
+  EXPECT_EQ(bucket->velocity_polygon_name_, "slow");
+
+  // Find bucket for 0.7 speed at 0 angle → fast
+  bucket = velocity_polygon_->callFindBucket(0.7, 0.0);
+  ASSERT_NE(bucket, nullptr);
+  EXPECT_EQ(bucket->velocity_polygon_name_, "fast");
+
+  // Out of range speed
+  bucket = velocity_polygon_->callFindBucket(1.5, 0.0);
+  EXPECT_EQ(bucket, nullptr);
+
+  // Out of range angle
+  bucket = velocity_polygon_->callFindBucket(0.3, 1.0);
+  EXPECT_EQ(bucket, nullptr);
+}
+
+TEST_F(Tester, testFindBucketsForAngle)
+{
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow", "fast"});
+  addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
+  addSteeringAngleSubPolygon("fast", 0.5, 1.0, -0.5, 0.5, STEERING_POLYGON_FAST_STR);
+  createSteeringVelocityPolygon("limit");
+
+  // At angle 0, both buckets should match, sorted by linear_min ascending
+  auto buckets = velocity_polygon_->callFindBucketsForAngle(0.0);
+  ASSERT_EQ(buckets.size(), 2u);
+  EXPECT_EQ(buckets[0]->velocity_polygon_name_, "slow");
+  EXPECT_EQ(buckets[1]->velocity_polygon_name_, "fast");
+
+  // At angle 1.0 (outside range), no buckets
+  buckets = velocity_polygon_->callFindBucketsForAngle(1.0);
+  EXPECT_EQ(buckets.size(), 0u);
+}
+
+// ==================== validateSteering tests ====================
+
+TEST_F(Tester, testValidateSteeringDirectionReversalHighSpeed)
+{
+  // Setup: 2 speed buckets with steering angle
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow", "fast"});
+  addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
+  addSteeringAngleSubPolygon("fast", 0.5, 1.0, -0.5, 0.5, STEERING_POLYGON_FAST_STR);
+  createSteeringVelocityPolygon("limit");
+
+  // Update polygon first so internal state is set
+  nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+
+  // Target: forward, Current: backward (speed crosses zero), |current| > threshold
+  nav2_collision_monitor::Velocity cmd_vel{0.5, 0.0, 0.3};  // forward target with steering
+  nav2_collision_monitor::Velocity odom_vel{-0.5, 0.0, 0.1};  // moving backward
+  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
+  collision_map["source"] = {};
+
+  nav2_collision_monitor::Action action{
+    nav2_collision_monitor::DO_NOTHING, cmd_vel, ""};
+
+  bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
+  EXPECT_TRUE(modified);
+  // Should clamp tw to maintain current steering angle
+  EXPECT_EQ(action.action_type, nav2_collision_monitor::LIMIT);
+}
+
+TEST_F(Tester, testValidateSteeringDirectionReversalLowSpeed)
+{
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow"});
+  addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
+  createSteeringVelocityPolygon("limit");
+
+  nav2_collision_monitor::Velocity vel{0.05, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+
+  // Target: forward, Current: backward but below threshold → allow steering freely
+  nav2_collision_monitor::Velocity cmd_vel{0.3, 0.0, 0.1};
+  nav2_collision_monitor::Velocity odom_vel{-0.05, 0.0, 0.0};  // below threshold
+  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
+  collision_map["source"] = {};
+
+  nav2_collision_monitor::Action action{
+    nav2_collision_monitor::DO_NOTHING, cmd_vel, ""};
+
+  bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
+  EXPECT_FALSE(modified);  // steering allowed freely
+}
+
+TEST_F(Tester, testValidateSteeringBothBelowThreshold)
+{
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow"});
+  addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
+  createSteeringVelocityPolygon("limit");
+
+  nav2_collision_monitor::Velocity vel{0.05, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+
+  // Both target and current below threshold → done (no modification)
+  nav2_collision_monitor::Velocity cmd_vel{0.05, 0.0, 0.02};
+  nav2_collision_monitor::Velocity odom_vel{0.05, 0.0, 0.01};
+  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
+  collision_map["source"] = {};
+
+  nav2_collision_monitor::Action action{
+    nav2_collision_monitor::DO_NOTHING, cmd_vel, ""};
+
+  bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(Tester, testValidateSteeringSameBucketAcceleratingNoCollision)
+{
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow", "fast"});
+  addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
+  addSteeringAngleSubPolygon("fast", 0.5, 1.0, -0.5, 0.5, STEERING_POLYGON_FAST_STR);
+  createSteeringVelocityPolygon("limit");
+
+  nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+
+  // Same bucket, accelerating, no collision in next bucket → no modification
+  nav2_collision_monitor::Velocity cmd_vel{0.4, 0.0, 0.0};  // target in slow bucket
+  nav2_collision_monitor::Velocity odom_vel{0.2, 0.0, 0.0};  // current in slow bucket
+  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
+  collision_map["source"] = {};  // no collision points
+
+  nav2_collision_monitor::Action action{
+    nav2_collision_monitor::DO_NOTHING, cmd_vel, ""};
+
+  bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(Tester, testValidateSteeringSameBucketAcceleratingWithCollision)
+{
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD, {"slow", "fast"});
+  addSteeringAngleSubPolygon("slow", 0.0, 0.5, -0.5, 0.5, STEERING_POLYGON_SLOW_STR);
+  addSteeringAngleSubPolygon("fast", 0.5, 1.0, -0.5, 0.5, STEERING_POLYGON_FAST_STR);
+  createSteeringVelocityPolygon("limit");
+
+  nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+
+  // Same bucket, accelerating, collision in next (fast) bucket → limit speed
+  // Use a high target speed that exceeds the slow bucket's max (0.5) after conversion,
+  // but still falls in the slow bucket because at non-zero steering angle sw speed is higher.
+  // At steering angle 0.3: sw_speed = 0.48 / cos(0.3) ≈ 0.503 → still slow bucket?
+  // Actually, let's use straight movement and a cmd_vel that tries to go to 0.6
+  // which would be in the fast bucket — wait, that's a different bucket test.
+  //
+  // The correct test: when in slow bucket and accelerating toward the upper limit,
+  // if there's collision in the fast bucket, the speed should be capped at slow bucket max.
+  // We need result_vel.x > slow_max for the limit to kick in.
+  // Set cmd_vel.x = 0.6 (which maps to fast bucket for target) — but then
+  // target_bucket != current_bucket and we'd be in the different-bucket branch.
+  //
+  // For the same-bucket case to limit, both must be in the same bucket AND
+  // the output velocity must exceed the bucket max. This happens when Step 1
+  // (the main polygon loop) didn't limit, but the steering check wants to cap.
+  // Use a robot_action that already has higher velocity from prior processing.
+  nav2_collision_monitor::Velocity cmd_vel{0.4, 0.0, 0.0};  // target in slow bucket
+  nav2_collision_monitor::Velocity odom_vel{0.2, 0.0, 0.0};  // current in slow bucket
+  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
+  // Place collision points inside the fast polygon
+  collision_map["source"] = {
+    {1.2, 0.0},   // inside fast polygon
+    {1.3, 0.1},   // inside fast polygon
+  };
+
+  // Set robot_action with a velocity that exceeds the slow bucket max
+  // (simulating that the main loop allowed higher speed)
+  nav2_collision_monitor::Velocity action_vel{0.6, 0.0, 0.0};
+  nav2_collision_monitor::Action action{
+    nav2_collision_monitor::DO_NOTHING, action_vel, ""};
+
+  bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
+  EXPECT_TRUE(modified);
+  EXPECT_EQ(action.action_type, nav2_collision_monitor::LIMIT);
+  // Speed should be limited to slow bucket's linear_max in baselink speed
+  // At 0 steering angle, that's just 0.5
+  EXPECT_LE(std::abs(action.req_vel.x), 0.5 + 1e-6);
+}
+
+TEST_F(Tester, testValidateSteeringDifferentBucketCollisionFree)
+{
+  // Buckets at different steering angles
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD,
+    {"straight_slow", "straight_fast", "left_slow", "left_fast"});
+  addSteeringAngleSubPolygon("straight_slow", 0.0, 0.5, -0.1, 0.1, STEERING_POLYGON_SLOW_STR);
+  addSteeringAngleSubPolygon("straight_fast", 0.5, 1.0, -0.1, 0.1, STEERING_POLYGON_FAST_STR);
+  addSteeringAngleSubPolygon("left_slow", 0.0, 0.5, 0.1, 0.5, STEERING_POLYGON_SLOW_STR);
+  addSteeringAngleSubPolygon("left_fast", 0.5, 1.0, 0.1, 0.5, STEERING_POLYGON_FAST_STR);
+  createSteeringVelocityPolygon("limit");
+
+  nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+
+  // Current: straight at 0.3, Target: left at 0.3
+  nav2_collision_monitor::Velocity odom_vel{0.3, 0.0, 0.0};  // straight
+  double target_sa = 0.3;
+  double target_tw = std::tan(target_sa) * 0.3 / WHEELBASE;
+  nav2_collision_monitor::Velocity cmd_vel{0.3, 0.0, target_tw};
+
+  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
+  collision_map["source"] = {};  // no collision
+
+  nav2_collision_monitor::Action action{
+    nav2_collision_monitor::DO_NOTHING, cmd_vel, ""};
+
+  bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
+  EXPECT_FALSE(modified);  // fastest bucket is collision-free → done
+}
+
+TEST_F(Tester, testValidateSteeringDifferentBucketAllCollision)
+{
+  // Buckets at different steering angles
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD,
+    {"straight_slow", "left_slow"});
+  addSteeringAngleSubPolygon("straight_slow", 0.0, 0.5, -0.1, 0.1, STEERING_POLYGON_SLOW_STR);
+  addSteeringAngleSubPolygon("left_slow", 0.0, 0.5, 0.1, 0.5, STEERING_POLYGON_SLOW_STR);
+  createSteeringVelocityPolygon("limit");
+
+  nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+
+  // Current: straight at 0.3, Target: left at 0.3
+  nav2_collision_monitor::Velocity odom_vel{0.3, 0.0, 0.0};
+  double target_sa = 0.3;
+  double target_tw = std::tan(target_sa) * 0.3 / WHEELBASE;
+  nav2_collision_monitor::Velocity cmd_vel{0.3, 0.0, target_tw};
+
+  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
+  // Collision in all left buckets
+  collision_map["source"] = {
+    {0.0, 0.0},
+    {0.2, 0.1},
+  };
+
+  nav2_collision_monitor::Action action{
+    nav2_collision_monitor::DO_NOTHING, cmd_vel, ""};
+
+  bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
+  EXPECT_TRUE(modified);
+  // No valid bucket → STOP
+  EXPECT_EQ(action.action_type, nav2_collision_monitor::STOP);
+  EXPECT_NEAR(action.req_vel.x, 0.0, 1e-6);
+  EXPECT_NEAR(action.req_vel.tw, 0.0, 1e-6);
+}
+
+TEST_F(Tester, testValidateSteeringDecelerationToValidBucket)
+{
+  // Setup: straight and left, each with slow and fast buckets
+  setSteeringVelocityPolygonParameters(WHEELBASE, LOW_SPEED_THRESHOLD,
+    {"straight_slow", "straight_fast", "left_slow", "left_fast"});
+  addSteeringAngleSubPolygon("straight_slow", 0.0, 0.5, -0.1, 0.1, STEERING_POLYGON_SLOW_STR);
+  addSteeringAngleSubPolygon("straight_fast", 0.5, 1.0, -0.1, 0.1, STEERING_POLYGON_FAST_STR);
+  addSteeringAngleSubPolygon("left_slow", 0.0, 0.5, 0.1, 0.5, STEERING_POLYGON_SLOW_STR);
+  addSteeringAngleSubPolygon("left_fast", 0.5, 1.0, 0.1, 0.5, STEERING_POLYGON_FAST_STR);
+  createSteeringVelocityPolygon("limit");
+
+  nav2_collision_monitor::Velocity vel{0.7, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+
+  // Current: straight at 0.7 (fast bucket), Target: left at 0.7 (fast bucket)
+  nav2_collision_monitor::Velocity odom_vel{0.7, 0.0, 0.0};
+  double target_sa = 0.3;
+  double target_tw = std::tan(target_sa) * 0.7 / WHEELBASE;
+  nav2_collision_monitor::Velocity cmd_vel{0.7, 0.0, target_tw};
+
+  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
+  // Collision in the fast left polygon only (points inside the large polygon)
+  collision_map["source"] = {
+    {1.2, 0.5},
+    {1.3, 0.6},
+  };
+
+  nav2_collision_monitor::Action action{
+    nav2_collision_monitor::DO_NOTHING, cmd_vel, ""};
+
+  bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
+  EXPECT_TRUE(modified);
+  EXPECT_EQ(action.action_type, nav2_collision_monitor::LIMIT);
+  // Speed should be limited to slow bucket's linear_max (0.5) converted to baselink
+  // At the target angle, baselink = 0.5 * cos(target_sa)
+  double expected_max = 0.5 * std::cos(target_sa);
+  EXPECT_LE(std::abs(action.req_vel.x), expected_max + 1e-3);
+}
+
+TEST_F(Tester, testValidateSteeringNotApplicableToNonSteering)
+{
+  // Create a normal theta-based velocity polygon (not steering angle)
+  createVelocityPolygon("stop", IS_NOT_HOLONOMIC);
+
+  nav2_collision_monitor::Velocity cmd_vel{0.3, 0.0, 0.0};
+  nav2_collision_monitor::Velocity odom_vel{0.2, 0.0, 0.0};
+  std::unordered_map<std::string, std::vector<nav2_collision_monitor::Point>> collision_map;
+  collision_map["source"] = {};
+
+  nav2_collision_monitor::Action action{
+    nav2_collision_monitor::DO_NOTHING, cmd_vel, ""};
+
+  bool modified = velocity_polygon_->validateSteering(cmd_vel, odom_vel, collision_map, action);
+  EXPECT_FALSE(modified);  // Should not apply to theta-based polygons
 }
 
 


### PR DESCRIPTION
## Summary
- **Steering wheel speed conversion**: `isInRange()` now converts baselink speed to steering wheel speed (`v_steering = v_baselink / cos(steering_angle)`) before checking linear range thresholds. `updatePolygon()` converts `linear_limit_` back to baselink speed.
- **Steering validation algorithm (Step 2)**: New `validateSteering()` method prevents steering into zones where obstacles would trigger a lidar e-stop. Handles direction reversal, same-bucket acceleration checks, different-bucket collision walk-down, and deceleration to valid buckets.
- **Helper methods**: `baselinkToSteeringSpeed`, `steeringToBaselinkSpeed`, `steeringAngleToTw`, `findBucket`, `findBucketsForAngle`, `isPointInsidePoly`, `getPointsInsideSubPolygon` + new `low_speed_threshold` parameter.
- **Bug fix**: Removed duplicate `addPolygonVelocitySubPolygon` definition in `collision_monitor_node_test.cpp`.

## Test plan
- [x] 18 new unit tests covering all steering conversion helpers, point-in-polygon, and every branch of `validateSteering` (direction reversal, same/different bucket, deceleration, non-steering bypass)
- [x] All 25 velocity_polygons_test pass
- [x] All 19 collision_monitor_node_test pass
- [x] All 27 polygons_test pass
- [x] All 2 kinematics_test pass
- [ ] Manual testing on robot with safety lidar e-stop zones

🤖 Generated with [Claude Code](https://claude.com/claude-code)