### PR TITLE
Add fields mode filtering to collision monitor velocity polygons

### DIFF
--- a/nav2_collision_monitor/README.md
+++ b/nav2_collision_monitor/README.md
@@ -62,6 +62,45 @@ The following diagram is showing the high-level design of Collision Monitor modu
 `VelocityPolygon` can be configured with multiple sub polygons and can switch between them based on the velocity.
 ![dexory_velocity_polygon.gif](doc/dexory_velocity_polygon.gif)
 
+#### Fields Mode Filtering
+
+Each `VelocityPolygon` sub-polygon can be assigned a list of **modes** it is active in. The Collision Monitor subscribes to a `fields_mode` topic (`std_msgs/String`) and only considers sub-polygons whose `modes` list contains the current mode. This enables different safety field configurations for different operating conditions without changing the polygon parameters at runtime.
+
+For example, a forklift robot might define:
+- **"default"** mode: normal lifted-fork fields with full speed range
+- **"fork_down"** mode: lowered-fork fields with reduced max speed
+- **"narrow_fork_down"** mode: narrow lowered-fork fields for tight spaces
+- **"foil"** mode: blind foil fields for specialized operation
+
+General direction fields (forward straight, slight turns) that have a pallet cutout can be active in all modes since they work for both lifted and lowered forks.
+
+Configuration example:
+```yaml
+collision_monitor:
+  ros__parameters:
+    fields_mode_topic: "fields_mode"  # Topic to receive mode string
+    VelocityPolygonLimit:
+      type: "velocity_polygon"
+      action_type: "limit"
+      velocity_polygons: ["forward_straight", "forward_straight_forkdown", "forward_left", ...]
+      forward_straight:
+        points: "[[...]]"
+        linear_min: 0.0
+        linear_max: 1.5
+        steering_angle_min: -0.2
+        steering_angle_max: 0.2
+        modes: ["default", "fork_down", "narrow", "narrow_fork_down"]  # general direction
+      forward_straight_forkdown:
+        points: "[[...]]"
+        linear_min: 0.0
+        linear_max: 0.7
+        steering_angle_min: -0.2
+        steering_angle_max: 0.2
+        modes: ["fork_down"]  # only active when forks lowered
+```
+
+When `modes` is not specified for a sub-polygon, it defaults to `["default"]`.
+
 
 ### Configuration
 

--- a/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/collision_monitor_node.hpp
@@ -37,6 +37,7 @@
 #include "nav2_util/twist_subscriber.hpp"
 #include "nav2_msgs/msg/collision_monitor_state.hpp"
 #include "nav2_msgs/srv/toggle.hpp"
+#include "std_msgs/msg/string.hpp"
 
 #include "nav2_collision_monitor/types.hpp"
 #include "nav2_collision_monitor/polygon.hpp"
@@ -113,6 +114,11 @@ protected:
    * @param msg Input odom message
    */
   void odomInCallback(nav_msgs::msg::Odometry::ConstSharedPtr msg);
+  /**
+   * @brief Callback for fields_mode topic
+   * @param msg String message containing the current fields mode
+   */
+  void fieldsModeCallback(std_msgs::msg::String::ConstSharedPtr msg);
   /**
    * @brief Publishes output cmd_vel. If robot was stopped more than stop_pub_timeout_ seconds,
    * quit to publish 0-velocity.
@@ -269,6 +275,10 @@ protected:
   rclcpp::Duration stop_pub_timeout_;
   /// @brief Active polygons publisher
   rclcpp::Publisher<nav2_msgs::msg::ActiveVelocityPolygons>::SharedPtr active_polygons_pub_;
+  /// @brief Fields mode subscriber
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr fields_mode_sub_;
+  /// @brief Current fields mode
+  std::string current_fields_mode_{"default"};
 };  // class CollisionMonitor
 
 }  // namespace nav2_collision_monitor

--- a/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
@@ -74,6 +74,18 @@ public:
    */
   void updatePolygon(const Velocity & cmd_vel_in) override;
 
+  /**
+   * @brief Set the current fields mode used for filtering sub-polygons
+   * @param mode Mode string (e.g. "default", "fork_down", "narrow_fork_down")
+   */
+  void setFieldsMode(const std::string & mode);
+
+  /**
+   * @brief Get the current fields mode
+   * @return Current mode string
+   */
+  std::string getFieldsMode() const;
+
 protected:
   /**
     * @brief Custom struct to store the parameters of the sub-polygon
@@ -91,6 +103,7 @@ protected:
     * @param linear_limit_ Robot linear limit
     * @param angular_limit_ Robot angular limit
     * @param time_before_collision_ Time before collision in seconds
+    * @param modes_ List of mode strings this sub-polygon is active in (e.g. "default", "fork_down")
     */
   struct SubPolygonParameter
   {
@@ -109,6 +122,7 @@ protected:
     double linear_limit_;
     double angular_limit_;
     double time_before_collision_;
+    std::vector<std::string> modes_;
   };
 
   /**
@@ -118,6 +132,13 @@ protected:
    * @return True if speed and direction is within the condition
    */
   bool isInRange(const Velocity & cmd_vel_in, const SubPolygonParameter & sub_polygon_param);
+
+  /**
+   * @brief Check if a sub-polygon is active in the current fields mode
+   * @param sub_polygon Sub-polygon to check
+   * @return True if the sub-polygon should be considered in the current mode
+   */
+  bool isSubPolygonActiveInCurrentMode(const SubPolygonParameter & sub_polygon) const;
 
   // Clock
   rclcpp::Clock::SharedPtr clock_;
@@ -130,6 +151,8 @@ protected:
   double current_steering_angle_;
   /// @brief Distance between front and rear axes
   double wheelbase_;
+  /// @brief Current fields mode for filtering sub-polygons
+  std::string current_fields_mode_{"default"};
   /// @brief Vector to store the parameters of the sub-polygon
   std::vector<SubPolygonParameter> sub_polygons_;
 };  // class VelocityPolygon

--- a/nav2_collision_monitor/params/collision_monitor_params.yaml
+++ b/nav2_collision_monitor/params/collision_monitor_params.yaml
@@ -53,6 +53,11 @@ collision_monitor:
       min_points: 6
       visualize: false
       enabled: true
+    # Topic for receiving the current fields mode (std_msgs/String)
+    # The mode string filters which velocity sub-polygons are active.
+    # Each sub-polygon has a "modes" list; only sub-polygons whose modes
+    # contain the current mode are considered. Default mode is "default".
+    fields_mode_topic: "fields_mode"
     VelocityPolygonStop:
       type: "velocity_polygon"
       action_type: "stop"
@@ -60,7 +65,7 @@ collision_monitor:
       visualize: true
       enabled: true
       polygon_pub_topic: "velocity_polygon_stop"
-      velocity_polygons: ["rotation", "translation_forward", "translation_backward", "stopped"]
+      velocity_polygons: ["rotation", "translation_forward", "translation_forward_forkdown", "translation_backward", "stopped"]
       holonomic: false
       rotation:
         points: "[[0.3, 0.3], [0.3, -0.3], [-0.3, -0.3], [-0.3, 0.3]]"
@@ -68,18 +73,31 @@ collision_monitor:
         linear_max: 0.05
         theta_min: -1.0
         theta_max: 1.0
+        # Active in all modes (general direction fields with pallet cutout)
+        modes: ["default", "fork_down", "narrow", "narrow_fork_down", "foil"]
       translation_forward:
         points: "[[0.35, 0.3], [0.35, -0.3], [-0.2, -0.3], [-0.2, 0.3]]"
         linear_min: 0.0
         linear_max: 1.0
         theta_min: -1.0
         theta_max: 1.0
+        # Only active in default and narrow modes (lifted forks)
+        modes: ["default", "narrow"]
+      translation_forward_forkdown:
+        points: "[[0.35, 0.3], [0.35, -0.3], [-0.2, -0.3], [-0.2, 0.3]]"
+        linear_min: 0.0
+        linear_max: 0.5
+        theta_min: -1.0
+        theta_max: 1.0
+        # Only active when forks are lowered
+        modes: ["fork_down", "narrow_fork_down"]
       translation_backward:
         points: "[[0.2, 0.3], [0.2, -0.3], [-0.35, -0.3], [-0.35, 0.3]]"
         linear_min: -1.0
         linear_max: 0.0
         theta_min: -1.0
         theta_max: 1.0
+        modes: ["default", "fork_down", "narrow", "narrow_fork_down", "foil"]
       # This is the last polygon to be checked, it should cover the entire range of robot's velocities
       # It is used as the stopped polygon when the robot is not moving and as a fallback if the velocity
       # is not covered by any of the other sub-polygons
@@ -89,6 +107,7 @@ collision_monitor:
         linear_max: 1.0
         theta_min: -1.0
         theta_max: 1.0
+        modes: ["default", "fork_down", "narrow", "narrow_fork_down", "foil"]
     observation_sources: ["scan"]
     scan:
       type: "scan"

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -78,6 +78,14 @@ CollisionMonitor::on_configure(const rclcpp_lifecycle::State & state)
     rclcpp::QoS(1));
 
   auto node = shared_from_this();
+
+  std::string fields_mode_topic = node->declare_or_get_parameter(
+    "fields_mode_topic", std::string("fields_mode"));
+  fields_mode_sub_ = this->create_subscription<std_msgs::msg::String>(
+    fields_mode_topic,
+    std::bind(&CollisionMonitor::fieldsModeCallback, this, std::placeholders::_1),
+    rclcpp::QoS(1).transient_local());
+
   cmd_vel_out_pub_ = std::make_unique<nav2_util::TwistPublisher>(node, cmd_vel_out_topic);
   active_polygons_pub_ = this->create_publisher<nav2_msgs::msg::ActiveVelocityPolygons>(
     "~/active_velocity_polygons");
@@ -185,6 +193,7 @@ CollisionMonitor::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   cmd_vel_out_pub_.reset();
   state_pub_.reset();
   collision_points_marker_pub_.reset();
+  fields_mode_sub_.reset();
 
   polygons_.clear();
   sources_.clear();
@@ -221,6 +230,24 @@ void CollisionMonitor::cmdVelInCallbackUnstamped(
   auto twist_stamped = std::make_shared<geometry_msgs::msg::TwistStamped>();
   twist_stamped->twist = *msg;
   cmdVelInCallbackStamped(twist_stamped);
+}
+
+void CollisionMonitor::fieldsModeCallback(std_msgs::msg::String::ConstSharedPtr msg)
+{
+  if (current_fields_mode_ != msg->data) {
+    RCLCPP_INFO(
+      get_logger(), "Fields mode changed from '%s' to '%s'",
+      current_fields_mode_.c_str(), msg->data.c_str());
+    current_fields_mode_ = msg->data;
+
+    // Propagate mode to all VelocityPolygon instances
+    for (auto & polygon : polygons_) {
+      auto vel_polygon = std::dynamic_pointer_cast<VelocityPolygon>(polygon);
+      if (vel_polygon) {
+        vel_polygon->setFieldsMode(current_fields_mode_);
+      }
+    }
+  }
 }
 
 void CollisionMonitor::odomInCallback(nav_msgs::msg::Odometry::ConstSharedPtr msg)

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -14,6 +14,8 @@
 
 #include "nav2_collision_monitor/velocity_polygon.hpp"
 
+#include <algorithm>
+
 #include "nav2_ros_common/node_utils.hpp"
 
 namespace nav2_collision_monitor
@@ -184,11 +186,36 @@ bool VelocityPolygon::getParameters(
           polygon_name_ + "." + velocity_polygon_name + ".simulation_time_step", 0.1);
       }
 
+      // Parse modes list - defaults to ["default"] if not specified
+      std::vector<std::string> modes;
+      try {
+        modes = node->declare_or_get_parameter<std::vector<std::string>>(
+          polygon_name_ + "." + velocity_polygon_name + ".modes");
+      } catch (const rclcpp::exceptions::ParameterNotDeclaredException &) {
+        modes = {"default"};
+      } catch (const rclcpp::exceptions::ParameterUninitializedException &) {
+        modes = {"default"};
+      } catch (const rclcpp::exceptions::InvalidParameterValueException &) {
+        modes = {"default"};
+      }
+
+      if (!modes.empty()) {
+        std::string modes_str;
+        for (const auto & m : modes) {
+          if (!modes_str.empty()) {modes_str += ", ";}
+          modes_str += m;
+        }
+        RCLCPP_INFO(
+          logger_, "[%s]: Sub-polygon %s active in modes: [%s]",
+          polygon_name_.c_str(), velocity_polygon_name.c_str(), modes_str.c_str());
+      }
+
       SubPolygonParameter sub_polygon = {
         poly, velocity_polygon_name, linear_min, linear_max, theta_min,
         theta_max, steering_angle_min, steering_angle_max, use_steering_angle,
         direction_end_angle, direction_start_angle,
         slowdown_ratio, linear_limit, angular_limit, time_before_collision,
+        modes,
       };
 
       sub_polygons_.push_back(sub_polygon);
@@ -202,9 +229,40 @@ bool VelocityPolygon::getParameters(
   return true;
 }
 
+void VelocityPolygon::setFieldsMode(const std::string & mode)
+{
+  if (current_fields_mode_ != mode) {
+    RCLCPP_INFO(
+      logger_, "[%s]: Fields mode changed from '%s' to '%s'",
+      polygon_name_.c_str(), current_fields_mode_.c_str(), mode.c_str());
+    current_fields_mode_ = mode;
+  }
+}
+
+std::string VelocityPolygon::getFieldsMode() const
+{
+  return current_fields_mode_;
+}
+
+bool VelocityPolygon::isSubPolygonActiveInCurrentMode(
+  const SubPolygonParameter & sub_polygon) const
+{
+  // If the sub-polygon has no modes specified, it's always active
+  if (sub_polygon.modes_.empty()) {
+    return true;
+  }
+  // Check if the current mode is in the sub-polygon's modes list
+  return std::find(
+    sub_polygon.modes_.begin(), sub_polygon.modes_.end(),
+    current_fields_mode_) != sub_polygon.modes_.end();
+}
+
 void VelocityPolygon::updatePolygon(const Velocity & cmd_vel_in)
 {
   for (auto & sub_polygon : sub_polygons_) {
+    if (!isSubPolygonActiveInCurrentMode(sub_polygon)) {
+      continue;
+    }
     if (isInRange(cmd_vel_in, sub_polygon)) {
       // Set the polygon that is within the speed range
       poly_ = sub_polygon.poly_;

--- a/nav2_collision_monitor/test/velocity_polygons_test.cpp
+++ b/nav2_collision_monitor/test/velocity_polygons_test.cpp
@@ -151,10 +151,12 @@ protected:
     const double linear_min, const double linear_max,
     const double theta_min, const double theta_max,
     const double direction_end_angle, const double direction_start_angle,
-    const std::string & polygon_points, const bool is_holonomic);
+    const std::string & polygon_points, const bool is_holonomic,
+    const std::vector<std::string> & modes = {});
 
   // Creating routines
   void createVelocityPolygon(const std::string & action_type, const bool is_holonomic);
+  void createVelocityPolygonWithModes(const std::string & action_type);
 
   // Wait until polygon will be received
   bool waitPolygon(
@@ -296,7 +298,8 @@ void Tester::addPolygonVelocitySubPolygon(
   const double linear_min, const double linear_max,
   const double theta_min, const double theta_max,
   const double direction_start_angle, const double direction_end_angle,
-  const std::string & polygon_points, const bool is_holonomic)
+  const std::string & polygon_points, const bool is_holonomic,
+  const std::vector<std::string> & modes)
 {
   test_node_->declare_parameter(
     std::string(POLYGON_NAME) + "." + sub_polygon_name + ".points",
@@ -331,12 +334,55 @@ void Tester::addPolygonVelocitySubPolygon(
       "." + sub_polygon_name + ".direction_start_angle",
       rclcpp::ParameterValue(direction_start_angle));
   }
+
+  if (!modes.empty()) {
+    test_node_->declare_parameter(
+      std::string(POLYGON_NAME) + "." + sub_polygon_name + ".modes",
+      rclcpp::ParameterValue(modes));
+  }
 }
 
 void Tester::createVelocityPolygon(const std::string & action_type, const bool is_holonomic)
 {
   setCommonParameters(POLYGON_NAME, action_type);
   setVelocityPolygonParameters(is_holonomic);
+
+  velocity_polygon_ = std::make_shared<VelocityPolygonWrapper>(
+    test_node_->weak_from_this(), POLYGON_NAME,
+    tf_buffer_, BASE_FRAME_ID, TRANSFORM_TOLERANCE);
+  ASSERT_TRUE(velocity_polygon_->configure());
+  velocity_polygon_->activate();
+}
+
+void Tester::createVelocityPolygonWithModes(const std::string & action_type)
+{
+  setCommonParameters(POLYGON_NAME, action_type);
+
+  test_node_->declare_parameter(
+    std::string(POLYGON_NAME) + ".holonomic", rclcpp::ParameterValue(false));
+
+  // Create two forward sub-polygons: one for "default" mode, one for "fork_down" mode
+  // with different speed ranges. The fork_down polygon has lower max speed.
+  static const char FWD_DEFAULT[]{"ForwardDefault"};
+  static const char FWD_FORKDOWN[]{"ForwardForkDown"};
+  static const char BWD[]{"Backward"};
+
+  std::vector<std::string> velocity_polygons = {FWD_DEFAULT, FWD_FORKDOWN, BWD};
+  test_node_->declare_parameter(
+    std::string(POLYGON_NAME) + ".velocity_polygons", rclcpp::ParameterValue(velocity_polygons));
+
+  // Forward default: speed 0..1.0, active in "default" mode
+  addPolygonVelocitySubPolygon(
+    FWD_DEFAULT, 0.0, 1.0, -1.0, 1.0, 0.0, 0.0, FORWARD_POLYGON_STR,
+    false, {"default"});
+  // Forward fork_down: speed 0..0.5, active in "fork_down" mode
+  addPolygonVelocitySubPolygon(
+    FWD_FORKDOWN, 0.0, 0.5, -1.0, 1.0, 0.0, 0.0, FORWARD_POLYGON_STR,
+    false, {"fork_down"});
+  // Backward: active in both modes
+  addPolygonVelocitySubPolygon(
+    BWD, -1.0, 0.0, -1.0, 1.0, 0.0, 0.0, BACKWARD_POLYGON_STR,
+    false, {"default", "fork_down"});
 
   velocity_polygon_ = std::make_shared<VelocityPolygonWrapper>(
     test_node_->weak_from_this(), POLYGON_NAME,
@@ -546,6 +592,131 @@ TEST_F(Tester, testVelocityPolygonHolonomicVelocitySwitching)
   EXPECT_NEAR(poly[3].y, RIGHT_POLYGON[7], EPSILON);
 }
 
+
+TEST_F(Tester, testFieldsModeDefaultFiltering)
+{
+  createVelocityPolygonWithModes("stop");
+
+  // In default mode, ForwardDefault (0..1.0) should be active, ForwardForkDown should not
+  ASSERT_EQ(velocity_polygon_->getFieldsMode(), "default");
+
+  // Forward velocity at 0.3 should match ForwardDefault
+  nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "ForwardDefault");
+
+  // Forward velocity at 0.8 should still match ForwardDefault (range is 0..1.0)
+  vel = {0.8, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "ForwardDefault");
+
+  // Backward should work
+  vel = {-0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "Backward");
+}
+
+TEST_F(Tester, testFieldsModeForkDownFiltering)
+{
+  createVelocityPolygonWithModes("stop");
+
+  // Switch to fork_down mode
+  velocity_polygon_->setFieldsMode("fork_down");
+  ASSERT_EQ(velocity_polygon_->getFieldsMode(), "fork_down");
+
+  // Forward velocity at 0.3 should match ForwardForkDown (0..0.5)
+  nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "ForwardForkDown");
+
+  // Forward velocity at 0.8 should NOT match any forward polygon (ForwardForkDown max is 0.5)
+  // ForwardDefault is not active in fork_down mode
+  vel = {0.8, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "none");
+
+  // Backward should still work (active in both modes)
+  vel = {-0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "Backward");
+}
+
+TEST_F(Tester, testFieldsModeUnknownModeFiltersAll)
+{
+  createVelocityPolygonWithModes("stop");
+
+  // Switch to an unknown mode - no sub-polygons should match
+  velocity_polygon_->setFieldsMode("nonexistent_mode");
+
+  nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "none");
+
+  vel = {-0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "none");
+}
+
+TEST_F(Tester, testFieldsModeSwitching)
+{
+  createVelocityPolygonWithModes("stop");
+
+  nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
+
+  // Start in default mode
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "ForwardDefault");
+
+  // Switch to fork_down
+  velocity_polygon_->setFieldsMode("fork_down");
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "ForwardForkDown");
+
+  // Switch back to default
+  velocity_polygon_->setFieldsMode("default");
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "ForwardDefault");
+}
+
+TEST_F(Tester, testFieldsModeSubPolygonModesStored)
+{
+  createVelocityPolygonWithModes("stop");
+
+  auto sub_polygons = velocity_polygon_->getSubPolygons();
+  ASSERT_EQ(sub_polygons.size(), 3u);
+
+  // ForwardDefault has modes: ["default"]
+  ASSERT_EQ(sub_polygons[0].modes_.size(), 1u);
+  EXPECT_EQ(sub_polygons[0].modes_[0], "default");
+
+  // ForwardForkDown has modes: ["fork_down"]
+  ASSERT_EQ(sub_polygons[1].modes_.size(), 1u);
+  EXPECT_EQ(sub_polygons[1].modes_[0], "fork_down");
+
+  // Backward has modes: ["default", "fork_down"]
+  ASSERT_EQ(sub_polygons[2].modes_.size(), 2u);
+  EXPECT_EQ(sub_polygons[2].modes_[0], "default");
+  EXPECT_EQ(sub_polygons[2].modes_[1], "fork_down");
+}
+
+TEST_F(Tester, testNoModesParameterDefaultsToAlwaysActive)
+{
+  // When no modes parameter is specified, sub-polygons should default to
+  // having modes: ["default"] and be active in "default" mode
+  createVelocityPolygon("stop", IS_NOT_HOLONOMIC);
+
+  auto sub_polygons = velocity_polygon_->getSubPolygons();
+  ASSERT_EQ(sub_polygons.size(), 2u);
+
+  // Sub-polygons without explicit modes get ["default"]
+  ASSERT_EQ(sub_polygons[0].modes_.size(), 1u);
+  EXPECT_EQ(sub_polygons[0].modes_[0], "default");
+
+  // They should work normally in default mode
+  nav2_collision_monitor::Velocity vel{0.3, 0.0, 0.0};
+  velocity_polygon_->updatePolygon(vel);
+  EXPECT_EQ(velocity_polygon_->getCurrentSubPolygonName(), "Forward");
+}
 
 int main(int argc, char ** argv)
 {


### PR DESCRIPTION
Each VelocityPolygon sub-polygon can now have a "modes" list parameter
(e.g. ["default", "fork_down", "narrow_fork_down"]). The collision
monitor subscribes to a "fields_mode" topic (std_msgs/String) and
only considers sub-polygons whose modes list contains the current
mode. This replaces the previous blind foil / fork down mode concepts
with a simpler, more flexible mode-based field filtering system.

Key changes:
- SubPolygonParameter gains a modes_ vector, defaulting to ["default"]
- VelocityPolygon::updatePolygon() skips sub-polygons not in current mode
- CollisionMonitor subscribes to fields_mode topic (transient local QoS)
- Mode changes propagate to all VelocityPolygon instances
- Tests cover mode filtering, switching, and default behavior

https://claude.ai/code/session_01T8z8rZjUHxxnXPFWMTBe2L