### PR TITLE
AMRNAV-7801 Fixed segmentation fault

### DIFF
--- a/nav2_controller/include/nav2_controller/plugins/feasible_path_handler.hpp
+++ b/nav2_controller/include/nav2_controller/plugins/feasible_path_handler.hpp
@@ -147,6 +147,11 @@ protected:
   bool reject_unit_path_, enforce_path_inversion_, enforce_path_rotation_;
   double max_robot_pose_search_dist_, transform_tolerance_, prune_distance_;
   float inversion_xy_tolerance_, inversion_yaw_tolerance_, minimum_rotation_angle_;
+  // Bumped by setPlan; findPlanSegment snapshots it; transformLocalPlan rejects
+  // the call if the snapshot no longer matches, so we never dereference iterators
+  // into a plan vector that was replaced on another thread.
+  uint64_t plan_version_{0u};
+  uint64_t cached_plan_version_{0u};
 
   /**
    * @brief Validate incoming parameter updates before applying them.

--- a/nav2_controller/plugins/feasible_path_handler.cpp
+++ b/nav2_controller/plugins/feasible_path_handler.cpp
@@ -134,6 +134,7 @@ void FeasiblePathHandler::setPlan(const nav_msgs::msg::Path & path)
     constraint_locale_ = nav2_util::removePosesAfterFirstConstraint(global_plan_up_to_constraint_,
       enforce_path_inversion_, minimum_rotation_angle_);
   }
+  ++plan_version_;
 }
 
 geometry_msgs::msg::PoseStamped FeasiblePathHandler::transformToGlobalPlanFrame(
@@ -195,6 +196,11 @@ nav2_core::PathSegment FeasiblePathHandler::findPlanSegment(
     nav2_util::geometry_utils::first_after_integrated_distance(
     closest_point, global_plan_up_to_constraint_.poses.end(), prune_distance_);
 
+  // Snapshot the plan version so transformLocalPlan can detect if setPlan
+  // replaced global_plan_up_to_constraint_ before we reacquire the mutex
+  // (which would leave the iterators we're returning dangling).
+  cached_plan_version_ = plan_version_;
+
   return {closest_point, pruned_plan_end};
 }
 
@@ -208,10 +214,24 @@ nav_msgs::msg::Path FeasiblePathHandler::transformLocalPlan(
   transformed_plan.header.frame_id = costmap_ros_->getGlobalFrameID();
   transformed_plan.header.stamp = global_pose_.header.stamp;
   unsigned int mx, my;
+
+  // The iterators we were handed may be dangling: setPlan can have replaced
+  // global_plan_up_to_constraint_.poses between findPlanSegment releasing the
+  // mutex and us reacquiring it. If the plan has changed in the meantime the
+  // segment findPlanSegment chose is no longer meaningful for the current
+  // plan — reject and let the controller retry with a fresh findPlanSegment
+  // call on its next tick.
+  if (cached_plan_version_ != plan_version_) {
+    throw nav2_core::InvalidPath(
+            "Global plan was replaced before transformLocalPlan could use it");
+  }
+  const nav2_core::PathIterator & plan_begin = closest_point;
+  const nav2_core::PathIterator & plan_end = pruned_plan_end;
+
   // Find the furthest relevant pose on the path to consider within costmap
   // bounds
   // Transforming it to the costmap frame in the same loop
-  for (auto global_plan_pose = closest_point; global_plan_pose != pruned_plan_end;
+  for (auto global_plan_pose = plan_begin; global_plan_pose != plan_end;
     ++global_plan_pose)
   {
     // Transform from global plan frame to costmap frame
@@ -234,7 +254,7 @@ nav_msgs::msg::Path FeasiblePathHandler::transformLocalPlan(
 
   // Remove the portion of the global plan that we've already passed so we don't
   // process it on the next iteration (this is called path pruning)
-  prunePlan(global_plan_up_to_constraint_, closest_point);
+  prunePlan(global_plan_up_to_constraint_, plan_begin);
 
   if ((enforce_path_inversion_ || enforce_path_rotation_) && constraint_locale_ != 0u) {
     if (isWithinInversionTolerances(global_pose_)) {


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [AMRNAV-7801](https://lvserv01.logivations.com/browse/AMRNAV-7801) |
| Primary OS tested on |Ubuntu|
| Robotic platform tested on | AMR multi-robot simulation (amr_simulation_simple, test_t5a_multi_amr_obstacle_avoidance) |
| Does this PR contain AI generated software? | Yes; comments in feasible_path_handler.cpp/.hpp explain the mechanism inline|
| Was this PR description generated by AI software? | No |

---

## Description of contribution in a few bullet points

Fixed a data race in FeasiblePathHandler that could crash nav2_controller under load.

computeAndPublishVelocity calls findPlanSegment (locks, returns iterators, unlocks), then transformLocalPlan (locks again). If setPlan runs in between, it replaces the plan and invalidates those iterators, leading to a crash when they’re used.

Solution:

Added a plan_version_ counter updated in setPlan.
findPlanSegment saves the version, transformLocalPlan checks it.
If it changed, throw nav2_core::InvalidPath so the controller retries instead of crashing.

No interface changes.

## Description of documentation updates required from your changes

None. No public API, parameter, or plugin-facing change.


#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
