### PR TITLE
Velocity polygon speed margin rel

### DIFF
--- a/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
+++ b/nav2_collision_monitor/include/nav2_collision_monitor/velocity_polygon.hpp
@@ -239,6 +239,16 @@ protected:
   double steeringAngleToTw(double baselink_speed, double steering_angle) const;
 
   /**
+   * @brief Compute the effective speed margin at a given field boundary.
+   * Combines the absolute floor (speed_margin_) with a boundary-proportional
+   * term (speed_margin_rel_ * |field_limit|). Used everywhere the algorithm
+   * caps commanded speed at a field's linear_max_/linear_min_.
+   * @param field_limit The field boundary being approached (linear_max_ or linear_min_)
+   * @return speed_margin_ + speed_margin_rel_ * std::abs(field_limit)
+   */
+  double effectiveSpeedMargin(double field_limit) const;
+
+  /**
    * @brief Find the field (sub-polygon) matching a given steering wheel speed and steering angle
    * @param steering_wheel_speed Speed in steering wheel frame
    * @param steering_angle Steering angle in radians
@@ -305,8 +315,10 @@ protected:
   double wheelbase_;
   /// @brief Speed below which steering is freely allowed
   double low_speed_threshold_;
-  /// @brief Speed margin (m/s) to stay inside field boundaries
+  /// @brief Absolute speed margin (m/s) to stay inside field boundaries
   double speed_margin_;
+  /// @brief Relative speed margin (fraction of field limit) added to speed_margin_
+  double speed_margin_rel_;
   /// @brief Angle margin (rad) to stay inside field boundaries
   double angle_margin_;
   /// @brief Current fields mode for filtering sub-polygons

--- a/nav2_collision_monitor/src/collision_monitor_node.cpp
+++ b/nav2_collision_monitor/src/collision_monitor_node.cpp
@@ -574,7 +574,7 @@ void CollisionMonitor::process(const Velocity & cmd_vel_in, const std_msgs::msg:
       // lower (e.g. narrow_fork_down caps at 0.15 m/s): updatePolygon() would
       // then find no match, emitting a spurious "velocity not covered" warning
       // and leaving a stale obstacle polygon for that cycle.
-      double probe_cap = 0.2;
+      double probe_cap = 0.1;
       if (auto vel_polygon = std::dynamic_pointer_cast<VelocityPolygon>(polygon)) {
         double mode_cap = vel_polygon->getMaxProbeSpeedForMode(cmd_vel_in.x >= 0.0);
         if (mode_cap > 0.0) {

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -77,7 +77,9 @@ bool VelocityPolygon::getParameters(
     low_speed_threshold_ = node->declare_or_get_parameter(
       polygon_name_ + ".low_speed_threshold", 0.1);
     speed_margin_ = node->declare_or_get_parameter(
-      polygon_name_ + ".speed_margin", 0.02);
+      polygon_name_ + ".speed_margin", 0.00625);
+    speed_margin_rel_ = node->declare_or_get_parameter(
+      polygon_name_ + ".speed_margin_rel", 0.0292);
     angle_margin_ = node->declare_or_get_parameter(
       polygon_name_ + ".angle_margin", 0.01);
 
@@ -409,6 +411,11 @@ bool VelocityPolygon::isInRange(
   return in_range;
 }
 
+double VelocityPolygon::effectiveSpeedMargin(double field_limit) const
+{
+  return speed_margin_ + speed_margin_rel_ * std::abs(field_limit);
+}
+
 double VelocityPolygon::computeSteeringAngle(const Velocity & vel) const
 {
   if (std::abs(vel.x) < 1e-6) {
@@ -512,7 +519,7 @@ double VelocityPolygon::getMaxProbeSpeedForMode(bool forward) const
   // Inset by the speed margin: isInRange() converts the probe to steering
   // wheel speed (hypot of linear and wheelbase*angular), which can land a hair
   // outside the field boundary if we probed exactly at the bound.
-  return std::max(0.0, max_abs - speed_margin_);
+  return std::max(0.0, max_abs - effectiveSpeedMargin(max_abs));
 }
 
 bool VelocityPolygon::isPointInsidePoly(
@@ -740,8 +747,8 @@ bool VelocityPolygon::validateSteering(
   bool forward_current = current_sw >= 0;
   auto fields_at_current_angle = findFieldsForAngle(current_sa, forward_current);
   double current_bucket_limit_sw = forward_current ?
-    current_field->linear_max_ - speed_margin_ :
-    current_field->linear_min_ + speed_margin_;
+    current_field->linear_max_ - effectiveSpeedMargin(current_field->linear_max_) :
+    current_field->linear_min_ + effectiveSpeedMargin(current_field->linear_min_);
   debug_msg.next_field_name = "no field found above";
 
   for (size_t i = 0; i < fields_at_current_angle.size(); i++) {
@@ -758,8 +765,8 @@ bool VelocityPolygon::validateSteering(
       debug_msg.next_field_collision_pts = pts;
       if (pts < min_points_) {
         current_bucket_limit_sw = forward_current ?
-          next_field->linear_max_ - speed_margin_ :
-          next_field->linear_min_ + speed_margin_;
+          next_field->linear_max_ - effectiveSpeedMargin(next_field->linear_max_) :
+          next_field->linear_min_ + effectiveSpeedMargin(next_field->linear_min_);
       }
     }
     break;
@@ -875,8 +882,8 @@ bool VelocityPolygon::validateSteering(
         // a later hard boundary or target cannot leave the commanded speed above
         // what an intermediate bucket admits.
         const double bucket_cap = forward ?
-          fastest_free->linear_max_ - speed_margin_ :
-          fastest_free->linear_min_ + speed_margin_;
+          fastest_free->linear_max_ - effectiveSpeedMargin(fastest_free->linear_max_) :
+          fastest_free->linear_min_ + effectiveSpeedMargin(fastest_free->linear_min_);
         if (std::abs(bucket_cap) < std::abs(barrier_limit_sw)) {
           barrier_limit_sw = bucket_cap;
         }
@@ -891,8 +898,8 @@ bool VelocityPolygon::validateSteering(
         // slower than the current speed. Slow toward the fastest one so the
         // bucket becomes enterable on a later cycle; hold at this bucket edge.
         const double cap = forward ?
-          fastest_free->linear_max_ - speed_margin_ :
-          fastest_free->linear_min_ + speed_margin_;
+          fastest_free->linear_max_ - effectiveSpeedMargin(fastest_free->linear_max_) :
+          fastest_free->linear_min_ + effectiveSpeedMargin(fastest_free->linear_min_);
         if (std::abs(cap) < std::abs(barrier_limit_sw)) {
           barrier_limit_sw = cap;
         }
@@ -909,8 +916,8 @@ bool VelocityPolygon::validateSteering(
       // only at its capped speed, and without cascading past this bucket.
       const SubPolygonParameter * slowest = next_fields.front();
       const double slowest_cap = forward ?
-        slowest->linear_max_ - speed_margin_ :
-        slowest->linear_min_ + speed_margin_;
+        slowest->linear_max_ - effectiveSpeedMargin(slowest->linear_max_) :
+        slowest->linear_min_ + effectiveSpeedMargin(slowest->linear_min_);
       if (std::abs(slowest_cap) < std::abs(barrier_limit_sw)) {
         barrier_limit_sw = slowest_cap;
       }
@@ -1013,7 +1020,8 @@ bool VelocityPolygon::clampToMaxField(
 
   // Max steering wheel speed for this field (inset by margin to stay inside)
   double max_sw = forward ?
-    fastest->linear_max_ - speed_margin_ : fastest->linear_min_ + speed_margin_;
+    fastest->linear_max_ - effectiveSpeedMargin(fastest->linear_max_) :
+    fastest->linear_min_ + effectiveSpeedMargin(fastest->linear_min_);
 
   // Compute commanded steering angle and steering wheel speed
   double cmd_sa = computeSteeringAngle(robot_action.req_vel);

--- a/nav2_collision_monitor/src/velocity_polygon.cpp
+++ b/nav2_collision_monitor/src/velocity_polygon.cpp
@@ -79,7 +79,7 @@ bool VelocityPolygon::getParameters(
     speed_margin_ = node->declare_or_get_parameter(
       polygon_name_ + ".speed_margin", 0.00625);
     speed_margin_rel_ = node->declare_or_get_parameter(
-      polygon_name_ + ".speed_margin_rel", 0.0292);
+      polygon_name_ + ".speed_margin_rel", 0.01);
     angle_margin_ = node->declare_or_get_parameter(
       polygon_name_ + ".angle_margin", 0.01);
 

--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -242,10 +242,11 @@ ControllerServer::on_activate(const rclcpp_lifecycle::State & /*state*/)
   vel_publisher_->on_activate();
   transformed_plan_pub_->on_activate();
   tracking_feedback_pub_->on_activate();
-  action_server_->activate();
-  param_handler_->activate();
 
-  // activate goal checker, progress checker and path handler
+  // initialize goal checker, progress checker and path handler before activating the
+  // action server: a goal accepted earlier would run computeControl() against plugins
+  // whose costmap_ros_/tf are still null (segfault in e.g.
+  // FeasiblePathHandler::getTransformedGoal)
   auto node = shared_from_this();
   for (auto & pc : progress_checkers_) {
     pc.second->initialize(node, pc.first);
@@ -258,6 +259,9 @@ ControllerServer::on_activate(const rclcpp_lifecycle::State & /*state*/)
       node, get_logger(), ph.first, costmap_ros_,
       costmap_ros_->getTfBuffer());
   }
+
+  action_server_->activate();
+  param_handler_->activate();
 
   // create bond connection
   createBond();


### PR DESCRIPTION
  ### Basic Info
                                                                                                                                                                         
  | Info                  | Please fill out this column                                                                          |                                       
  | --------------------- | ---------------------------------------------------------------------------------------------------- |
  | Platform tested on    | AMR                                                                                                  |                                       
  | Related documentation | nav2_collision_monitor/README.md (steering validation, Steps 4–6 — updated in this PR)               |                                       
  | Ticket                |                                                                                                      |                                       
                                                                                                                                                                         
  ### Description of contribution                                                                                                                                        
                                                            
  Reason for change:                                                                                                                                                     
   
  The steering-wheel–domain validation in `VelocityPolygon` (introduced on `lidar_fields_validation_2`) had two structural weaknesses that surfaced on the AMR. First,   
  the old Step 4–6 stepped exactly one bucket toward the target per cycle: if the immediate neighbour admitted the current speed, the wheel snapped to the target angle,
  but the commanded *speed* was only capped against the current bucket and that single neighbour — so a multi-bucket advance toward a coverage boundary could leave the  
  commanded speed above what an intermediate or final bucket actually admits, and the wheel could dive toward the target angle while the AMR was still too fast for the
  field it was entering. Second, `speed_margin_` was a single absolute value (0.02 m/s) applied at every field boundary; on low-speed fields that is a large fraction of
  the field's max, on high-speed fields it is negligible relative to sensor and control noise so the resulting velocity still lands on the boundary and the next cycle's
  `findField` can fall into a gap. Additionally, the reachability check used `|current_sw|` against `|linear_min_|`/`|linear_max_|`, and backward fields have
  `linear_max_ ≈ 0`, so `|sw| <= |linear_max_|` was unsatisfiable for any reverse motion — the wheel froze near straight when reversing toward a fully-turned angle.

  Changes in this PR:

  - **Speed ramp — rewrite Step 4–6 of `VelocityPolygon::validateSteering`** (`src/velocity_polygon.cpp:787+`)                                                           
      - Advance the steering angle as far toward the target as is valid at the *current* steering-wheel speed, walking buckets one step at a time. A bucket is reachable
  if it has a collision-free field whose speed range includes the current speed.                                                                                         
      - Stop at the first "cliff" (no collision-free field ≥ current speed, or no field at all in the current mode) and slow the commanded speed toward the fastest
  available field in that blocking bucket, so the bucket becomes enterable on a later cycle. Deceleration leads steering — the commanded `(angle, speed)` is always      
  inside a real lidar field.                                
      - **Escape hatch for fully-occupied neighbour.** If every field in the next bucket is in collision (obstacle already inside even the smallest field, velocity      
  polygons are enlarged relative to the real lidar e-stop zone), allow entering via the slowest field, capped to that field's max, without cascading further.            
  - **Speed ramp 2 — barrier tracks every entered bucket** (`src/velocity_polygon.cpp:834+`)
      - The speed barrier now records the capacity (fastest collision-free field max) of *every* bucket entered on the way to the reachable edge, not just the blocking  
  or target bucket. A multi-bucket advance to a coverage boundary can no longer leave the speed above any traversed bucket's max.                                        
      - **Fix backward-reachability sign bug** (`src/velocity_polygon.cpp:798+`): replace `|sw|` magnitude checks with a signed `[linear_min_, linear_max_]` range test  
  (matching `findField()`), so reversing toward a fully-turned angle is correctly recognized as reachable.                                                               
      - **Cache neighbour-field point counts** so debug-msg population and barrier decisions do not re-run `getPointsInsideSubPolygon` on the same fields.
      - **Angle-margin inset never overshoots `current_sa`.** For buckets narrower than `angle_margin_`, the previous `reachable_edge - dir * angle_margin_` could steer 
  *back past* the current angle into the previous bucket; now clamped with `std::max`/`std::min` against `current_sa`.                                                   
  - **Relative speed margin** (`velocity_polygon.hpp:238–318`, `src/velocity_polygon.cpp`)                                                                               
      - New parameter `speed_margin_rel_` (default 0.0292). Combined with the existing `speed_margin_` as `effective = speed_margin_ + speed_margin_rel_ *               
  |field_limit|`, applied at every boundary inset in `getMaxProbeSpeedForMode`, `validateSteering`, and `clampToMaxField`. High-speed fields get proportionally more     
  inset; low-speed fields are no longer over-penalised.
      - Absolute default lowered from `speed_margin_ = 0.02 → 0.00625 m/s` to keep the sum near the previous value at typical field maxes.                               
  - **README updated** (`nav2_collision_monitor/README.md`) — Steps 4–6 rewritten to describe multi-bucket advance, cliff/escape-hatch semantics, and the "barrier tracks
   every entered bucket" guarantee.                                                                                                                                      
  - **New tests** (`test/velocity_polygons_test.cpp`, ~200 lines): staircase-of-buckets fixture covering (a) fast-straight-cliff holds at boundary, (b) slow-straight    
  reaches full target angle, (c) mid-straight advances to intermediate bucket edge, (d) multi-bucket advance caps speed to reachable-bucket max, (e)                     
  too-fast-for-slowest-occupied field holds at boundary (escape-hatch boundary), (f) backward-slow reverse reaches fully-turned target angle (regression for the sign 
  bug).