### PR TITLE
controller_server: initialize plugins before activating the action server (fixes 0x5f0 segfault)

### DIFF
--- a/nav2_controller/src/controller_server.cpp
+++ b/nav2_controller/src/controller_server.cpp
@@ -242,10 +242,11 @@ ControllerServer::on_activate(const rclcpp_lifecycle::State & /*state*/)
   vel_publisher_->on_activate();
   transformed_plan_pub_->on_activate();
   tracking_feedback_pub_->on_activate();
-  action_server_->activate();
-  param_handler_->activate();
 
-  // activate goal checker, progress checker and path handler
+  // initialize goal checker, progress checker and path handler before activating the
+  // action server: a goal accepted earlier would run computeControl() against plugins
+  // whose costmap_ros_/tf are still null (segfault in e.g.
+  // FeasiblePathHandler::getTransformedGoal)
   auto node = shared_from_this();
   for (auto & pc : progress_checkers_) {
     pc.second->initialize(node, pc.first);
@@ -258,6 +259,9 @@ ControllerServer::on_activate(const rclcpp_lifecycle::State & /*state*/)
       node, get_logger(), ph.first, costmap_ros_,
       costmap_ros_->getTfBuffer());
   }
+
+  action_server_->activate();
+  param_handler_->activate();
 
   // create bond connection
   createBond();


### PR DESCRIPTION
## Symptom

Recurring daily gazebo system-test crash in `test_amr_gazebo_camera_correction_steering_spike` (deep_cv builds #73194/#73195/#73197 on 2026-07-21, #73134 on 2026-07-20 — identical trace each time):

```
#0 nav2_controller::FeasiblePathHandler::getTransformedGoal(builtin_interfaces::msg::Time const&)
#1 nav2_controller::ControllerServer::computeAndPublishVelocity()
#2 nav2_controller::ControllerServer::computeControl()
Segmentation fault (Address not mapped to object [0x5f0])
```

always immediately after "Received a goal, begin computing control effort." on the **first** control cycle, while the rest of the stack is still activating.

## Root cause

`ControllerServer::on_activate()` calls `action_server_->activate()` **before** the initialize loops for progress checkers, goal checkers, and path handlers. A FollowPath goal accepted in that window (the steering-spike test sends `follow_path` right at startup, racing lifecycle activation) executes `computeControl()` against a `FeasiblePathHandler` whose `initialize()` hasn't run yet:

- `setPlan()` succeeds — it only stores the path,
- `getTransformedGoal()` then dereferences the still-null `costmap_ros_`.

Disassembly of `libfeasible_path_handler.so` confirms it: the faulting instruction is `mov 0x5f0(%rax),%rcx` with `%rax = *(this+0xb0)` (the null `costmap_ros_` shared_ptr), i.e. the inlined `costmap_ros_->getGlobalFrameID()` reading `Costmap2DROS::global_frame_` at member offset 0x5f0 — which is exactly the reported fault address, and why it's byte-identical across runs.

## Fix

Move the three plugin initialize loops ahead of `action_server_->activate()` (and `param_handler_->activate()`), so no goal can start executing against uninitialized plugins. This also fixes the silent variant of the same window where an early goal runs progress/goal checkers with uninitialized parameters.

## Verification

- `colcon build --packages-select nav2_controller` compiles clean against the current workspace.
- The crash is a startup race, so the real gate is the daily `test_amr_gazebo_camera_correction_steering_spike` runs going green (it segfaulted on 4 of 10 firings across 2026-07-20/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)