### PR TITLE
AMRNAV-7900 Footprint-aware free-space stop checker

### DIFF
--- a/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/a_star.hpp
@@ -55,7 +55,8 @@ public:
   typedef typename NodeT::CoordinateVector CoordinateVector;
   typedef typename NodeVector::iterator NeighborIterator;
   typedef std::function<bool (const uint64_t &, NodeT * &)> NodeGetter;
-  typedef std::function<bool (const float &, const float &)> FreeSpaceStopChecker;
+  // (x, y, theta) in map cells / radians; theta is 0 for nodes without a heading
+  typedef std::function<bool (const float &, const float &, const float &)> FreeSpaceStopChecker;
   typedef GoalManager<NodeT> GoalManagerT;
   using NodeContext = typename NodeT::NodeContext;
 

--- a/nav2_smac_planner/include/nav2_smac_planner/no_waiting_zone.hpp
+++ b/nav2_smac_planner/include/nav2_smac_planner/no_waiting_zone.hpp
@@ -21,7 +21,9 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <vector>
 
+#include "geometry_msgs/msg/point.hpp"
 #include "nav_msgs/msg/occupancy_grid.hpp"
 #include "nav2_core/planner_exceptions.hpp"
 #include "nav2_costmap_2d/costmap_2d.hpp"
@@ -96,8 +98,9 @@ public:
    * @param global_frame Global frame of the planner, to validate the zone frame
    * @return Stop checker functor
    */
-  std::function<bool(const float &, const float &)> createFreeSpaceStopChecker(
-    const nav2_costmap_2d::Costmap2D * costmap, const std::string & global_frame)
+  std::function<bool(const float &, const float &, const float &)> createFreeSpaceStopChecker(
+    const nav2_costmap_2d::Costmap2D * costmap, const std::string & global_frame,
+    const std::vector<geometry_msgs::msg::Point> & footprint = {})
   {
     nav_msgs::msg::OccupancyGrid::ConstSharedPtr grid;
     {
@@ -122,12 +125,65 @@ public:
     const double resolution = costmap->getResolution();
     const double origin_x = costmap->getOriginX();
     const double origin_y = costmap->getOriginY();
-    return [grid, origin_x, origin_y, resolution, threshold, padding](
-      const float & mx, const float & my) -> bool {
+    return [grid, origin_x, origin_y, resolution, threshold, padding, footprint](
+      const float & mx, const float & my, const float & theta) -> bool {
         const double wx = origin_x + (static_cast<double>(mx) + 0.5) * resolution;
         const double wy = origin_y + (static_cast<double>(my) + 0.5) * resolution;
-        return !isInZone(*grid, wx, wy, threshold, padding);
+        return !footprintInZone(*grid, wx, wy, theta, footprint, threshold, padding);
       };
+  }
+
+  /**
+   * @brief Check if the robot footprint, placed at a pose, overlaps the no-waiting zone.
+   * A single point cannot describe an elongated robot: an isotropic padding large enough to
+   * cover it inflates the zone by the circumscribed radius in every direction, which can leave
+   * no reachable stop position at all in a narrow corridor. The zone is a filled region, so
+   * sampling the footprint outline at grid resolution finds every overlap a fill test would;
+   * the centre is tested too for the degenerate case of a zone smaller than the robot.
+   * @param grid Zone occupancy grid
+   * @param wx World X of the robot origin
+   * @param wy World Y of the robot origin
+   * @param theta Robot heading in radians
+   * @param footprint Robot footprint in the robot frame; empty falls back to a point check
+   * @param occupied_threshold Minimum occupancy value considered inside the zone
+   * @param padding Minimum clearance to the zone in meters (<= 0 disables)
+   * @return If any part of the footprint lies inside the (padded) no-waiting zone
+   */
+  static bool footprintInZone(
+    const nav_msgs::msg::OccupancyGrid & grid,
+    const double & wx, const double & wy, const double & theta,
+    const std::vector<geometry_msgs::msg::Point> & footprint,
+    const int8_t & occupied_threshold,
+    const double & padding = 0.0)
+  {
+    if (isInZone(grid, wx, wy, occupied_threshold, padding)) {
+      return true;
+    }
+    if (footprint.size() < 3) {
+      return false;
+    }
+
+    const double cs = std::cos(theta);
+    const double sn = std::sin(theta);
+    const double step = std::max(grid.info.resolution * 0.5, 1e-3);
+
+    for (size_t i = 0; i < footprint.size(); ++i) {
+      const auto & p0 = footprint[i];
+      const auto & p1 = footprint[(i + 1) % footprint.size()];
+      const double ax = wx + p0.x * cs - p0.y * sn;
+      const double ay = wy + p0.x * sn + p0.y * cs;
+      const double bx = wx + p1.x * cs - p1.y * sn;
+      const double by = wy + p1.x * sn + p1.y * cs;
+      const int samples = std::max(1, static_cast<int>(std::ceil(std::hypot(bx - ax, by - ay) /
+        step)));
+      for (int k = 0; k <= samples; ++k) {
+        const double t = static_cast<double>(k) / static_cast<double>(samples);
+        if (isInZone(grid, ax + (bx - ax) * t, ay + (by - ay) * t, occupied_threshold, padding)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /**

--- a/nav2_smac_planner/src/a_star.cpp
+++ b/nav2_smac_planner/src/a_star.cpp
@@ -335,7 +335,16 @@ bool AStarAlgorithm<NodeT>::checkFreeSpaceStop(
 {
   const Coordinates node_coords =
     NodeT::getCoords(current_node->getIndex(), getSizeX(), getSizeDim3());
-  if (!_free_space_stop_checker(node_coords.x, node_coords.y)) {
+
+  // Coordinates carry theta as a bin index; the checker wants radians so it can place the
+  // robot footprint. Node2D has no heading (and no motion table) - pass 0.
+  float theta = 0.0f;
+  if constexpr (!std::is_same_v<NodeT, Node2D>) {
+    theta = _shared_ctx->motion_table.getAngleFromBin(
+      static_cast<unsigned int>(node_coords.theta));
+  }
+
+  if (!_free_space_stop_checker(node_coords.x, node_coords.y, theta)) {
     return false;
   }
 

--- a/nav2_smac_planner/src/smac_planner_hybrid.cpp
+++ b/nav2_smac_planner/src/smac_planner_hybrid.cpp
@@ -424,7 +424,8 @@ nav_msgs::msg::Path SmacPlannerHybrid::createPlan(
     // Ignore the goal: fan out from the start and stop at the cheapest-to-reach
     // pose outside of the no-waiting zone
     _a_star->enableFreeSpaceSearch(
-      _no_waiting_zone.createFreeSpaceStopChecker(costmap, _global_frame));
+      _no_waiting_zone.createFreeSpaceStopChecker(
+        costmap, _global_frame, _costmap_ros->getRobotFootprint()));
   } else {
     _a_star->disableFreeSpaceSearch();
 

--- a/nav2_smac_planner/test/test_a_star.cpp
+++ b/nav2_smac_planner/test/test_a_star.cpp
@@ -201,7 +201,7 @@ TEST(AStarTest, test_a_star_2d_free_space_search)
   // cheapest reachable stop from (50, 50) is straight left at (29, 50)
   a_star.setStart(50u, 50u, 0);
   a_star.enableFreeSpaceSearch(
-    [](const float & x, const float & /*y*/) {
+    [](const float & x, const float & /*y*/, const float & /*theta*/) {
       return x < 30.0f || x > 70.0f;
     });
 
@@ -227,7 +227,7 @@ TEST(AStarTest, test_a_star_2d_free_space_search)
   a_star.setCollisionChecker(checker.get());
   a_star.setStart(50u, 50u, 0);
   a_star.enableFreeSpaceSearch(
-    [](const float & /*x*/, const float & /*y*/) {
+    [](const float & /*x*/, const float & /*y*/, const float & /*theta*/) {
       return true;
     });
   EXPECT_TRUE(a_star.createPath(path, num_it, tolerance, dummy_cancel_checker));
@@ -241,7 +241,7 @@ TEST(AStarTest, test_a_star_2d_free_space_search)
   a_star.setCollisionChecker(checker.get());
   a_star.setStart(50u, 50u, 0);
   a_star.enableFreeSpaceSearch(
-    [](const float & /*x*/, const float & /*y*/) {
+    [](const float & /*x*/, const float & /*y*/, const float & /*theta*/) {
       return false;
     });
   EXPECT_FALSE(a_star.createPath(path, num_it, tolerance, dummy_cancel_checker));
@@ -312,7 +312,7 @@ TEST(AStarTest, test_a_star_se2_free_space_search)
   a_star.setCollisionChecker(checker.get());
   a_star.setStart(50u, 50u, 0u);
   a_star.enableFreeSpaceSearch(
-    [](const float & x, const float & /*y*/) {
+    [](const float & x, const float & /*y*/, const float & /*theta*/) {
       return x < 30.0f || x > 70.0f;
     });
 


### PR DESCRIPTION


<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

The free-space search stopped when the robot ORIGIN left the no-waiting zone, using an isotropic padding as a stand-in for the robot's extent. With an elongated, asymmetric footprint (forks vs body) and a reversing exit, that let part of the robot hang inside the zone.

Pass the node heading into the stop checker (FreeSpaceStopChecker gains a theta arg; Node2D passes 0 and keeps its point behaviour) and test the full oriented footprint outline against the zone instead of a single point. Padding becomes a plain safety margin. The footprint comes from costmap_ros->getRobotFootprint(), wired through for the Hybrid planner.

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
